### PR TITLE
Change types from `OsStr` to `AsRef<Path>`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "gengo"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "criterion",
  "git2",
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "gengo-bin"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "clap",
  "gengo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["gengo", "gengo-bin"]
 
 [workspace.package]
 description = "Get the language distribution stats of your repository"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 repository = "https://github.com/spenserblack/gengo"
 readme = "README.md"

--- a/gengo-bin/Cargo.toml
+++ b/gengo-bin/Cargo.toml
@@ -15,7 +15,7 @@ name = "gengo"
 
 [dependencies]
 clap = { version = "4", features = ["derive", "wrap_help"] }
-gengo = { path = "../gengo", version = "0.2" }
+gengo = { path = "../gengo", version = "0.3" }
 indexmap = "2"
 
 [dev-dependencies]

--- a/gengo/src/documentation.rs
+++ b/gengo/src/documentation.rs
@@ -9,7 +9,8 @@ impl Documentation {
     }
 
     fn is_documentation_no_read<P: AsRef<Path>>(filepath: P) -> bool {
-        filepath.as_ref()
+        filepath
+            .as_ref()
             .components()
             .next()
             .map_or(false, |c| c.as_os_str() == "docs")
@@ -35,9 +36,6 @@ mod tests {
         case("docs", true)
     )]
     fn test_is_documentation_no_read(filepath: &str, expected: bool) {
-        assert_eq!(
-            Documentation::is_documentation_no_read(filepath),
-            expected
-        );
+        assert_eq!(Documentation::is_documentation_no_read(filepath), expected);
     }
 }

--- a/gengo/src/documentation.rs
+++ b/gengo/src/documentation.rs
@@ -1,21 +1,21 @@
-use std::{ffi::OsStr, path::Path};
+use std::path::Path;
 
 pub struct Documentation;
 
 impl Documentation {
-    pub fn is_documentation(filepath: &OsStr, contents: &[u8]) -> bool {
-        Self::is_documentation_no_read(filepath)
-            || Self::is_documentation_with_read(filepath, contents)
+    pub fn is_documentation<P: AsRef<Path>>(filepath: P, contents: &[u8]) -> bool {
+        Self::is_documentation_no_read(&filepath)
+            || Self::is_documentation_with_read(&filepath, contents)
     }
 
-    fn is_documentation_no_read(filepath: &OsStr) -> bool {
-        Path::new(filepath)
+    fn is_documentation_no_read<P: AsRef<Path>>(filepath: P) -> bool {
+        filepath.as_ref()
             .components()
             .next()
             .map_or(false, |c| c.as_os_str() == "docs")
     }
 
-    fn is_documentation_with_read(_filepath: &OsStr, _contents: &[u8]) -> bool {
+    fn is_documentation_with_read<P: AsRef<Path>>(_filepath: P, _contents: &[u8]) -> bool {
         false
     }
 }
@@ -36,7 +36,7 @@ mod tests {
     )]
     fn test_is_documentation_no_read(filepath: &str, expected: bool) {
         assert_eq!(
-            Documentation::is_documentation_no_read(OsStr::new(filepath)),
+            Documentation::is_documentation_no_read(filepath),
             expected
         );
     }

--- a/gengo/src/generated.rs
+++ b/gengo/src/generated.rs
@@ -1,20 +1,20 @@
-use std::{ffi::OsStr, path::Path};
+use std::path::Path;
 
 pub struct Generated;
 
 impl Generated {
-    pub fn is_generated(filepath: &OsStr, contents: &[u8]) -> bool {
-        Self::is_generated_no_read(filepath) || Self::is_generated_with_read(filepath, contents)
+    pub fn is_generated<P: AsRef<Path>>(filepath: P, contents: &[u8]) -> bool {
+        Self::is_generated_no_read(&filepath) || Self::is_generated_with_read(&filepath, contents)
     }
 
-    fn is_generated_no_read(filepath: &OsStr) -> bool {
-        Path::new(filepath)
+    fn is_generated_no_read<P: AsRef<Path>>(filepath: P) -> bool {
+        filepath.as_ref()
             .components()
             .next()
             .map_or(false, |c| c.as_os_str() == "dist")
     }
 
-    fn is_generated_with_read(_filepath: &OsStr, _contents: &[u8]) -> bool {
+    fn is_generated_with_read<P: AsRef<Path>>(_filepath: P, _contents: &[u8]) -> bool {
         false
     }
 }
@@ -35,7 +35,7 @@ mod tests {
     )]
     fn test_is_generated_no_read(filepath: &str, expected: bool) {
         assert_eq!(
-            Generated::is_generated_no_read(OsStr::new(filepath)),
+            Generated::is_generated_no_read(filepath),
             expected
         );
     }

--- a/gengo/src/generated.rs
+++ b/gengo/src/generated.rs
@@ -8,7 +8,8 @@ impl Generated {
     }
 
     fn is_generated_no_read<P: AsRef<Path>>(filepath: P) -> bool {
-        filepath.as_ref()
+        filepath
+            .as_ref()
             .components()
             .next()
             .map_or(false, |c| c.as_os_str() == "dist")
@@ -34,9 +35,6 @@ mod tests {
         case("dist", true)
     )]
     fn test_is_generated_no_read(filepath: &str, expected: bool) {
-        assert_eq!(
-            Generated::is_generated_no_read(filepath),
-            expected
-        );
+        assert_eq!(Generated::is_generated_no_read(filepath), expected);
     }
 }

--- a/gengo/src/languages/analyzer.rs
+++ b/gengo/src/languages/analyzer.rs
@@ -85,7 +85,12 @@ impl Analyzers {
     /// If none of the found heuristics match, returns the original matches.
     ///
     /// Use `limit` to limit the number of bytes to read to match to heuristics.
-    pub fn with_heuristics<P: AsRef<Path>>(&self, filepath:P, contents: &[u8], limit: usize) -> Found {
+    pub fn with_heuristics<P: AsRef<Path>>(
+        &self,
+        filepath: P,
+        contents: &[u8],
+        limit: usize,
+    ) -> Found {
         let contents = if contents.len() > limit {
             &contents[..limit]
         } else {
@@ -154,7 +159,12 @@ impl Analyzers {
     /// let language = analyzers.pick(filename, contents, limit).unwrap();
     /// assert_eq!(language.name(), "Rust");
     /// ```
-    pub fn pick<P: AsRef<Path>>(&self, filepath: P, contents: &[u8], limit: usize) -> Option<&Language> {
+    pub fn pick<P: AsRef<Path>>(
+        &self,
+        filepath: P,
+        contents: &[u8],
+        limit: usize,
+    ) -> Option<&Language> {
         let matches = self.with_heuristics(filepath, contents, limit);
         let matches = match matches {
             Found::None => return None,

--- a/gengo/src/lib.rs
+++ b/gengo/src/lib.rs
@@ -7,8 +7,7 @@ pub use languages::analyzer::Analyzers;
 use languages::Category;
 pub use languages::Language;
 use std::error::Error;
-use std::ffi::OsStr;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use vendored::Vendored;
 
 mod builder;
@@ -36,7 +35,7 @@ impl Gengo {
     }
 
     /// Analyzes each file in the repository at the given revision.
-    pub fn analyze(&self, rev: &str) -> Result<IndexMap<String, Entry>, Box<dyn Error>> {
+    pub fn analyze(&self, rev: &str) -> Result<IndexMap<PathBuf, Entry>, Box<dyn Error>> {
         let mut results = IndexMap::new();
         let commit = self.rev(rev)?;
         let tree = commit.tree()?;
@@ -48,7 +47,7 @@ impl Gengo {
         &self,
         root: &str,
         tree: &Tree,
-        results: &mut IndexMap<String, Entry>,
+        results: &mut IndexMap<PathBuf, Entry>,
     ) -> Result<(), Box<dyn Error>> {
         for entry in tree.iter() {
             let object = entry.to_object(&self.repository)?;
@@ -75,22 +74,21 @@ impl Gengo {
         Ok(())
     }
 
-    fn analyze_blob(
+    fn analyze_blob<P: AsRef<Path>>(
         &self,
-        filepath: &OsStr,
+        filepath: P,
         blob: &Blob,
-        results: &mut IndexMap<String, Entry>,
+        results: &mut IndexMap<PathBuf, Entry>,
     ) -> Result<(), Box<dyn Error>> {
-        let path = Path::new(filepath);
         let contents = blob.content();
 
         let lang_override = self
-            .get_str_attr(path, "gengo-language")?
+            .get_str_attr(&filepath, "gengo-language")?
             .map(|s| s.replace('-', " "))
             .and_then(|s| self.analyzers.get(&s));
 
         let language =
-            lang_override.or_else(|| self.analyzers.pick(filepath, contents, self.read_limit));
+            lang_override.or_else(|| self.analyzers.pick(&filepath, contents, self.read_limit));
 
         let language = if let Some(language) = language {
             language.clone()
@@ -100,14 +98,14 @@ impl Gengo {
 
         let size = contents.len();
         let generated = self
-            .get_boolean_attr(path, "gengo-generated")?
-            .unwrap_or_else(|| self.is_generated(filepath, contents));
+            .get_boolean_attr(&filepath, "gengo-generated")?
+            .unwrap_or_else(|| self.is_generated(&filepath, contents));
         let documentation = self
-            .get_boolean_attr(path, "gengo-documentation")?
-            .unwrap_or_else(|| self.is_documentation(filepath, contents));
+            .get_boolean_attr(&filepath, "gengo-documentation")?
+            .unwrap_or_else(|| self.is_documentation(&filepath, contents));
         let vendored = self
-            .get_boolean_attr(path, "gengo-vendored")?
-            .unwrap_or_else(|| self.is_vendored(filepath, contents));
+            .get_boolean_attr(&filepath, "gengo-vendored")?
+            .unwrap_or_else(|| self.is_vendored(&filepath, contents));
 
         let detectable = match language.category() {
             Category::Data | Category::Prose => false,
@@ -116,10 +114,10 @@ impl Gengo {
             }
         };
         let detectable = self
-            .get_boolean_attr(path, "gengo-detectable")?
+            .get_boolean_attr(&filepath, "gengo-detectable")?
             .unwrap_or(detectable);
 
-        let path = String::from(filepath.to_str().ok_or("invalid path")?);
+        let path_buf = filepath.as_ref().to_path_buf();
         let entry = Entry {
             language,
             size,
@@ -129,37 +127,37 @@ impl Gengo {
             vendored,
         };
 
-        results.insert(path, entry);
+        results.insert(path_buf, entry);
 
         Ok(())
     }
 
     /// Guesses if a file is generated.
-    pub fn is_generated(&self, filepath: &OsStr, contents: &[u8]) -> bool {
+    pub fn is_generated<P: AsRef<Path>>(&self, filepath: P, contents: &[u8]) -> bool {
         Generated::is_generated(filepath, contents)
     }
 
     /// Guesses if a file is documentation.
-    pub fn is_documentation(&self, filepath: &OsStr, contents: &[u8]) -> bool {
+    pub fn is_documentation<P: AsRef<Path>>(&self, filepath: P, contents: &[u8]) -> bool {
         Documentation::is_documentation(filepath, contents)
     }
 
     /// Guesses if a file is vendored.
-    pub fn is_vendored(&self, filepath: &OsStr, contents: &[u8]) -> bool {
+    pub fn is_vendored<P: AsRef<Path>>(&self, filepath: P, contents: &[u8]) -> bool {
         Vendored::is_vendored(filepath, contents)
     }
 
-    fn get_attr(&self, path: &Path, attr: &str) -> Result<AttrValue, Box<dyn Error>> {
+    fn get_attr<P: AsRef<Path>>(&self, path: P, attr: &str) -> Result<AttrValue, Box<dyn Error>> {
         let flags = Self::ATTR_CHECK_FLAGS
             .into_iter()
             .reduce(|a, b| a | b)
             .unwrap();
-        let attr = self.repository.get_attr(path, attr, flags)?;
+        let attr = self.repository.get_attr(path.as_ref(), attr, flags)?;
         let attr = AttrValue::from_string(attr);
         Ok(attr)
     }
 
-    fn get_boolean_attr(&self, path: &Path, attr: &str) -> Result<Option<bool>, Box<dyn Error>> {
+    fn get_boolean_attr<P: AsRef<Path>>(&self, path: P, attr: &str) -> Result<Option<bool>, Box<dyn Error>> {
         let attr = self.get_attr(path, attr)?;
         let attr = match attr {
             AttrValue::True => Some(true),
@@ -171,7 +169,7 @@ impl Gengo {
         Ok(attr)
     }
 
-    fn get_str_attr(&self, path: &Path, attr: &str) -> Result<Option<String>, Box<dyn Error>> {
+    fn get_str_attr<P: AsRef<Path>>(&self, path: P, attr: &str) -> Result<Option<String>, Box<dyn Error>> {
         let attr = self.get_attr(path, attr)?;
         let attr = match attr {
             AttrValue::String(s) => Some(s),

--- a/gengo/src/lib.rs
+++ b/gengo/src/lib.rs
@@ -157,7 +157,11 @@ impl Gengo {
         Ok(attr)
     }
 
-    fn get_boolean_attr<P: AsRef<Path>>(&self, path: P, attr: &str) -> Result<Option<bool>, Box<dyn Error>> {
+    fn get_boolean_attr<P: AsRef<Path>>(
+        &self,
+        path: P,
+        attr: &str,
+    ) -> Result<Option<bool>, Box<dyn Error>> {
         let attr = self.get_attr(path, attr)?;
         let attr = match attr {
             AttrValue::True => Some(true),
@@ -169,7 +173,11 @@ impl Gengo {
         Ok(attr)
     }
 
-    fn get_str_attr<P: AsRef<Path>>(&self, path: P, attr: &str) -> Result<Option<String>, Box<dyn Error>> {
+    fn get_str_attr<P: AsRef<Path>>(
+        &self,
+        path: P,
+        attr: &str,
+    ) -> Result<Option<String>, Box<dyn Error>> {
         let attr = self.get_attr(path, attr)?;
         let attr = match attr {
             AttrValue::String(s) => Some(s),

--- a/gengo/src/vendored.rs
+++ b/gengo/src/vendored.rs
@@ -8,7 +8,8 @@ impl Vendored {
     }
 
     fn is_vendored_no_read<P: AsRef<Path>>(filepath: P) -> bool {
-        filepath.as_ref()
+        filepath
+            .as_ref()
             .components()
             .next()
             .map_or(false, |c| c.as_os_str() == "node_modules")
@@ -34,9 +35,6 @@ mod tests {
         case("node_modules", true)
     )]
     fn test_is_vendored_no_read(filepath: &str, expected: bool) {
-        assert_eq!(
-            Vendored::is_vendored_no_read(filepath),
-            expected
-        );
+        assert_eq!(Vendored::is_vendored_no_read(filepath), expected);
     }
 }

--- a/gengo/src/vendored.rs
+++ b/gengo/src/vendored.rs
@@ -1,20 +1,20 @@
-use std::{ffi::OsStr, path::Path};
+use std::path::Path;
 
 pub struct Vendored;
 
 impl Vendored {
-    pub fn is_vendored(filepath: &OsStr, contents: &[u8]) -> bool {
-        Self::is_vendored_no_read(filepath) || Self::is_vendored_with_read(filepath, contents)
+    pub fn is_vendored<P: AsRef<Path>>(filepath: P, contents: &[u8]) -> bool {
+        Self::is_vendored_no_read(&filepath) || Self::is_vendored_with_read(&filepath, contents)
     }
 
-    fn is_vendored_no_read(filepath: &OsStr) -> bool {
-        Path::new(filepath)
+    fn is_vendored_no_read<P: AsRef<Path>>(filepath: P) -> bool {
+        filepath.as_ref()
             .components()
             .next()
             .map_or(false, |c| c.as_os_str() == "node_modules")
     }
 
-    fn is_vendored_with_read(_filepath: &OsStr, _contents: &[u8]) -> bool {
+    fn is_vendored_with_read<P: AsRef<Path>>(_filepath: P, _contents: &[u8]) -> bool {
         false
     }
 }
@@ -35,7 +35,7 @@ mod tests {
     )]
     fn test_is_vendored_no_read(filepath: &str, expected: bool) {
         assert_eq!(
-            Vendored::is_vendored_no_read(OsStr::new(filepath)),
+            Vendored::is_vendored_no_read(filepath),
             expected
         );
     }

--- a/gengo/tests/analyzers_tests.rs
+++ b/gengo/tests/analyzers_tests.rs
@@ -1,6 +1,5 @@
 use gengo::Analyzers;
 use insta::assert_debug_snapshot;
-use std::ffi::OsStr;
 
 mod util;
 
@@ -8,7 +7,7 @@ mod util;
 fn test_by_filepath_json_with_comments() {
     let fixture = fixture_str!("test_check_json_with_comments-analyzers.yaml");
     let analyzers = Analyzers::from_yaml(fixture).unwrap();
-    let results = analyzers.by_filepath(OsStr::new("test.json"));
+    let results = analyzers.by_filepath("test.json");
     assert_debug_snapshot!(results);
 }
 
@@ -31,18 +30,18 @@ fn test_simple() {
     );
     assert_debug_snapshot!(
         "analyzers_tests__test_simple__by_filepath",
-        analyzers.by_filepath(OsStr::new("test.sh"))
+        analyzers.by_filepath("test.sh")
     );
     assert_debug_snapshot!(
         "analyzers_tests__test_simple",
-        analyzers.simple(OsStr::new("test.sh"), contents)
+        analyzers.simple("test.sh", contents)
     );
 }
 
 #[test]
 fn test_with_heuristics() {
     let fixture = fixture_str!("test_check_json_with_comments-analyzers.yaml");
-    let filepath = OsStr::new("test.json");
+    let filepath = "test.json";
     let contents = fixture_bytes!("test_check_json_with_comments-file.json");
     let analyzers = Analyzers::from_yaml(fixture).unwrap();
     assert_debug_snapshot!(
@@ -58,7 +57,7 @@ fn test_with_heuristics() {
 #[test]
 fn test_no_heuristic_match_returns_original_set() {
     let fixture = fixture_str!("test_check_json_with_comments-analyzers.yaml");
-    let filepath = OsStr::new("test.json");
+    let filepath = "test.json";
     let contents = br#"{"type": "maybe not JSON with comments"}"#;
     let analyzers = Analyzers::from_yaml(fixture).unwrap();
     let result = analyzers.with_heuristics(filepath, contents, 1 << 20);
@@ -72,7 +71,7 @@ fn test_no_heuristic_match_returns_original_set() {
 #[test]
 fn test_pick_find_one() {
     let fixture = fixture_str!("test_check_json_with_comments-analyzers.yaml");
-    let filepath = OsStr::new("test.json");
+    let filepath = "test.json";
     let contents = fixture_bytes!("test_check_json_with_comments-file.json");
     let analyzers = Analyzers::from_yaml(fixture).unwrap();
     let language = analyzers.pick(filepath, contents, 1 << 20).unwrap();
@@ -82,7 +81,7 @@ fn test_pick_find_one() {
 #[test]
 fn test_pick_find_none() {
     let fixture = fixture_str!("test_check_json_with_comments-analyzers.yaml");
-    let filepath = OsStr::new("test.yaml");
+    let filepath = "test.yaml";
     let contents = b"---\nfoo: bar\n";
     let analyzers = Analyzers::from_yaml(fixture).unwrap();
     let language = analyzers.pick(filepath, contents, 1);
@@ -92,7 +91,7 @@ fn test_pick_find_none() {
 #[test]
 fn test_pick_find_multiple() {
     let fixture = fixture_str!("test_check_json_with_comments-analyzers.yaml");
-    let filepath = OsStr::new("test.json");
+    let filepath = "test.json";
     let contents = br#"{"msg": "Comments? IDK"}"#;
     let analyzers = Analyzers::from_yaml(fixture).unwrap();
     let language = analyzers.pick(filepath, contents, 1 << 20).unwrap();

--- a/gengo/tests/snapshots/analyzers_tests__analyzers_tests__test_simple.snap
+++ b/gengo/tests/snapshots/analyzers_tests__analyzers_tests__test_simple.snap
@@ -1,6 +1,6 @@
 ---
 source: gengo/tests/analyzers_tests.rs
-expression: "analyzers.simple(OsStr::new(\"test.sh\"), contents)"
+expression: "analyzers.simple(\"test.sh\", contents)"
 ---
 One(
     "fish",

--- a/gengo/tests/snapshots/analyzers_tests__analyzers_tests__test_simple__by_filepath.snap
+++ b/gengo/tests/snapshots/analyzers_tests__analyzers_tests__test_simple__by_filepath.snap
@@ -1,6 +1,6 @@
 ---
 source: gengo/tests/analyzers_tests.rs
-expression: "analyzers.by_filepath(OsStr::new(\"test.sh\"))"
+expression: "analyzers.by_filepath(\"test.sh\")"
 ---
 One(
     "shell",


### PR DESCRIPTION
This allows more flexibility, as multiple common types like `str` and
`OsStr` implement `AsRef<Path>`.

This is *almost* a non-breaking change, but the key of the returned map
is changed, which is breaking.

Resolves #28
