### PR TITLE
chore: Build benches in separate step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,5 +87,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 3
+      - name: Build Benchmarks
+        run: cargo build --benches
       - name: Run Benchmarks
         run: cargo bench


### PR DESCRIPTION
This should hopefully make the step that runs benches less verbose, so
viewers don't have to scroll as much to see the results.
