### PR TITLE
Fix matcher priorities

### DIFF
--- a/docs/analysis-state-diagram.mmd
+++ b/docs/analysis-state-diagram.mmd
@@ -5,6 +5,8 @@ flowchart TD
     start[Start]
     pass1[Check shebangs]
     pass1part2[Check filenames]
+    pass1part3[Check filepath patterns]
+    pass1part4[Check extensions]
     result1[Return languages]
     pass2[Heuristics]
     result2branch1[Return languages from heuristics]
@@ -14,7 +16,11 @@ flowchart TD
     start --> pass1
     pass1 -->|Shebang matches| result1
     pass1 -->|No matching shebangs| pass1part2
-    pass1part2 --> result1
+    pass1part2 -->|filename matches| result1
+    pass1part2 -->|No matching filenames| pass1part3
+    pass1part3 -->|filepath matches| result1
+    pass1part3 -->|No matching filepaths| pass1part4
+    pass1part4 -->result1
     result1 -->|0 or 1 matching languages| stop
     result1 -->|2 or more matching languages| pass2
     pass2 -->|1 matching language| stop

--- a/gengo/src/languages/analyzer.rs
+++ b/gengo/src/languages/analyzer.rs
@@ -1,13 +1,13 @@
 //! Analyzes a language.
 use super::{Category, Language, LANGUAGE_DEFINITIONS};
-use glob::Pattern;
-use indexmap::{IndexMap, IndexSet};
-use once_cell::sync::Lazy;
+
+use indexmap::IndexMap;
+
 use regex::Regex;
 use serde::Deserialize;
 use std::error::Error;
-use std::ffi::{OsStr, OsString};
-use std::fmt::Display;
+
+use super::matcher::{Filepath, Matcher, Shebang};
 use std::path::Path;
 
 /// Analyzes and attempts to identify a language.
@@ -302,106 +302,6 @@ impl IntoIterator for Found {
     }
 }
 
-/// Checks if a file matches.
-#[derive(Clone, Debug)]
-#[non_exhaustive]
-pub enum Matcher {
-    Filepath(FilepathMatcher),
-    Shebang(ShebangMatcher),
-}
-
-/// Matches a file path.
-#[derive(Clone, Debug)]
-pub struct FilepathMatcher {
-    extensions: IndexSet<OsString>,
-    filenames: IndexSet<OsString>,
-    patterns: Vec<Pattern>,
-}
-
-impl FilepathMatcher {
-    /// Create a new filepath matcher.
-    fn new<S: AsRef<OsStr>>(extensions: &[S], filenames: &[S], patterns: &[String]) -> Self {
-        let extensions = extensions.iter().map(Into::into).collect();
-        let filenames = filenames.iter().map(Into::into).collect();
-        let patterns = patterns
-            .iter()
-            .map(|s| Pattern::new(s.as_ref()).unwrap())
-            .collect();
-        Self {
-            extensions,
-            filenames,
-            patterns,
-        }
-    }
-
-    pub fn matches_extension<P: AsRef<Path>>(&self, filename: P) -> bool {
-        let extension = filename.as_ref().extension().unwrap_or_default();
-        self.extensions.contains(extension)
-    }
-
-    pub fn matches_filename<P: AsRef<Path>>(&self, filename: P) -> bool {
-        self.filenames
-            .contains(filename.as_ref().file_name().unwrap_or_default())
-    }
-
-    pub fn matches_pattern<P: AsRef<Path>>(&self, filename: P) -> bool {
-        self.patterns
-            .iter()
-            .any(|p| p.matches_path(filename.as_ref()))
-    }
-
-    pub fn matches<P: AsRef<Path>>(&self, filename: P) -> bool {
-        self.matches_extension(&filename)
-            || self.matches_filename(&filename)
-            || self.matches_pattern(&filename)
-    }
-}
-
-/// Matches a shebang.
-#[derive(Clone, Debug)]
-pub struct ShebangMatcher {
-    interpreters: IndexSet<String>,
-}
-
-impl ShebangMatcher {
-    const MAX_SHEBANG_LENGTH: usize = 50;
-
-    fn new<S: Display>(interpreters: &[S]) -> Self {
-        let interpreters = interpreters.iter().map(|s| s.to_string()).collect();
-        Self { interpreters }
-    }
-
-    /// Checks if the file contents match a shebang by checking the first line of the contents.
-    ///
-    /// Does not read more than 100 bytes.
-    pub fn matches(&self, contents: &[u8]) -> bool {
-        let mut lines = contents.split(|&c| c == b'\n');
-        let first_line = lines.next().unwrap_or_default();
-        // Check that the first line is a shebang
-        if first_line.len() < 2 || first_line[0] != b'#' || first_line[1] != b'!' {
-            return false;
-        }
-        let first_line = if first_line.len() > Self::MAX_SHEBANG_LENGTH {
-            &first_line[..Self::MAX_SHEBANG_LENGTH]
-        } else {
-            first_line
-        };
-        let first_line = String::from_utf8_lossy(first_line);
-        // NOTE Handle trailing spaces, `\r`, etc.
-        let first_line = first_line.trim_end();
-        static RE: Lazy<Regex> = Lazy::new(|| {
-            Regex::new(r"^#!(?:/usr(?:/local)?)?/bin/(?:env )?([\w\d]+)\r?$").unwrap()
-        });
-
-        RE.captures(first_line)
-            .and_then(|c| c.get(1))
-            .map_or(false, |m| {
-                let interpreter = m.as_str();
-                self.interpreters.contains(interpreter)
-            })
-    }
-}
-
 #[derive(Debug, Deserialize)]
 struct AnalyzerArgs {
     category: Category,
@@ -442,7 +342,7 @@ impl From<&AnalyzerArgMatchers> for Vec<Matcher> {
         let shebang_matcher = if matchers.interpreters.is_empty() {
             None
         } else {
-            let shebang_matcher = ShebangMatcher::new(&matchers.interpreters);
+            let shebang_matcher = Shebang::new(&matchers.interpreters);
             Some(Matcher::Shebang(shebang_matcher))
         };
         [filepath_matcher, shebang_matcher]
@@ -452,54 +352,12 @@ impl From<&AnalyzerArgMatchers> for Vec<Matcher> {
     }
 }
 
-impl From<&AnalyzerArgMatchers> for FilepathMatcher {
+impl From<&AnalyzerArgMatchers> for Filepath {
     fn from(matchers: &AnalyzerArgMatchers) -> Self {
         Self::new(
             &matchers.extensions,
             &matchers.filenames,
             &matchers.patterns,
         )
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use rstest::rstest;
-
-    #[test]
-    fn test_matches_extension() {
-        let analyzer = FilepathMatcher::new(&["txt"], &[], &[]);
-        assert!(analyzer.matches("foo.txt"));
-        assert!(!analyzer.matches("foo.rs"));
-    }
-
-    #[test]
-    fn test_matches_filename() {
-        let analyzer = FilepathMatcher::new(&[], &["LICENSE"], &[]);
-        assert!(analyzer.matches("LICENSE"));
-        assert!(!analyzer.matches("Dockerfile"));
-    }
-
-    #[rstest(
-        pattern,
-        filename,
-        case("Makefile.*", "Makefile.in"),
-        case(".vscode/*.json", ".vscode/extensions.json")
-    )]
-    fn test_matches_pattern(pattern: &str, filename: &str) {
-        let analyzer = FilepathMatcher::new::<&str>(&[], &[], &[pattern.into()]);
-        assert!(analyzer.matches(filename));
-    }
-
-    #[test]
-    fn test_matches_shebang() {
-        let analyzer = ShebangMatcher::new(&["python", "python3"]);
-        assert!(analyzer.matches(b"#!/bin/python\n"));
-        assert!(analyzer.matches(b"#!/usr/bin/python\n"));
-        assert!(analyzer.matches(b"#!/usr/local/bin/python\n"));
-        assert!(analyzer.matches(b"#!/usr/bin/python3\n"));
-        assert!(analyzer.matches(b"#!/usr/bin/env python\n"));
-        assert!(!analyzer.matches(b"#!/bin/sh\n"));
     }
 }

--- a/gengo/src/languages/matcher.rs
+++ b/gengo/src/languages/matcher.rs
@@ -1,0 +1,150 @@
+use glob::Pattern;
+use indexmap::IndexSet;
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+use std::ffi::{OsStr, OsString};
+use std::fmt::Display;
+use std::path::Path;
+
+/// Checks if a file matches.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub enum Matcher {
+    Filepath(Filepath),
+    Shebang(Shebang),
+}
+
+/// Matches a file path.
+#[derive(Clone, Debug)]
+pub struct Filepath {
+    extensions: IndexSet<OsString>,
+    filenames: IndexSet<OsString>,
+    patterns: Vec<Pattern>,
+}
+
+impl Filepath {
+    /// Create a new filepath matcher.
+    pub fn new<S: AsRef<OsStr>>(extensions: &[S], filenames: &[S], patterns: &[String]) -> Self {
+        let extensions = extensions.iter().map(Into::into).collect();
+        let filenames = filenames.iter().map(Into::into).collect();
+        let patterns = patterns
+            .iter()
+            .map(|s| Pattern::new(s.as_ref()).unwrap())
+            .collect();
+        Self {
+            extensions,
+            filenames,
+            patterns,
+        }
+    }
+
+    pub fn matches_extension<P: AsRef<Path>>(&self, filename: P) -> bool {
+        let extension = filename.as_ref().extension().unwrap_or_default();
+        self.extensions.contains(extension)
+    }
+
+    pub fn matches_filename<P: AsRef<Path>>(&self, filename: P) -> bool {
+        self.filenames
+            .contains(filename.as_ref().file_name().unwrap_or_default())
+    }
+
+    pub fn matches_pattern<P: AsRef<Path>>(&self, filename: P) -> bool {
+        self.patterns
+            .iter()
+            .any(|p| p.matches_path(filename.as_ref()))
+    }
+
+    pub fn matches<P: AsRef<Path>>(&self, filename: P) -> bool {
+        self.matches_extension(&filename)
+            || self.matches_filename(&filename)
+            || self.matches_pattern(&filename)
+    }
+}
+
+/// Matches a shebang.
+#[derive(Clone, Debug)]
+pub struct Shebang {
+    interpreters: IndexSet<String>,
+}
+
+impl Shebang {
+    const MAX_SHEBANG_LENGTH: usize = 50;
+
+    pub fn new<S: Display>(interpreters: &[S]) -> Self {
+        let interpreters = interpreters.iter().map(|s| s.to_string()).collect();
+        Self { interpreters }
+    }
+
+    /// Checks if the file contents match a shebang by checking the first line of the contents.
+    ///
+    /// Does not read more than 100 bytes.
+    pub fn matches(&self, contents: &[u8]) -> bool {
+        let mut lines = contents.split(|&c| c == b'\n');
+        let first_line = lines.next().unwrap_or_default();
+        // Check that the first line is a shebang
+        if first_line.len() < 2 || first_line[0] != b'#' || first_line[1] != b'!' {
+            return false;
+        }
+        let first_line = if first_line.len() > Self::MAX_SHEBANG_LENGTH {
+            &first_line[..Self::MAX_SHEBANG_LENGTH]
+        } else {
+            first_line
+        };
+        let first_line = String::from_utf8_lossy(first_line);
+        // NOTE Handle trailing spaces, `\r`, etc.
+        let first_line = first_line.trim_end();
+        static RE: Lazy<Regex> = Lazy::new(|| {
+            Regex::new(r"^#!(?:/usr(?:/local)?)?/bin/(?:env )?([\w\d]+)\r?$").unwrap()
+        });
+
+        RE.captures(first_line)
+            .and_then(|c| c.get(1))
+            .map_or(false, |m| {
+                let interpreter = m.as_str();
+                self.interpreters.contains(interpreter)
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[test]
+    fn test_matches_extension() {
+        let analyzer = Filepath::new(&["txt"], &[], &[]);
+        assert!(analyzer.matches("foo.txt"));
+        assert!(!analyzer.matches("foo.rs"));
+    }
+
+    #[test]
+    fn test_matches_filename() {
+        let analyzer = Filepath::new(&[], &["LICENSE"], &[]);
+        assert!(analyzer.matches("LICENSE"));
+        assert!(!analyzer.matches("Dockerfile"));
+    }
+
+    #[rstest(
+        pattern,
+        filename,
+        case("Makefile.*", "Makefile.in"),
+        case(".vscode/*.json", ".vscode/extensions.json")
+    )]
+    fn test_matches_pattern(pattern: &str, filename: &str) {
+        let analyzer = Filepath::new::<&str>(&[], &[], &[pattern.into()]);
+        assert!(analyzer.matches(filename));
+    }
+
+    #[test]
+    fn test_matches_shebang() {
+        let analyzer = Shebang::new(&["python", "python3"]);
+        assert!(analyzer.matches(b"#!/bin/python\n"));
+        assert!(analyzer.matches(b"#!/usr/bin/python\n"));
+        assert!(analyzer.matches(b"#!/usr/local/bin/python\n"));
+        assert!(analyzer.matches(b"#!/usr/bin/python3\n"));
+        assert!(analyzer.matches(b"#!/usr/bin/env python\n"));
+        assert!(!analyzer.matches(b"#!/bin/sh\n"));
+    }
+}

--- a/gengo/src/languages/mod.rs
+++ b/gengo/src/languages/mod.rs
@@ -1,5 +1,6 @@
 use serde::Deserialize;
 pub mod analyzer;
+mod matcher;
 
 const LANGUAGE_DEFINITIONS: &str = include_str!(concat!(env!("OUT_DIR"), "/languages.json"));
 

--- a/gengo/tests/analyzers_tests.rs
+++ b/gengo/tests/analyzers_tests.rs
@@ -7,7 +7,7 @@ mod util;
 fn test_by_filepath_json_with_comments() {
     let fixture = fixture_str!("test_check_json_with_comments-analyzers.yaml");
     let analyzers = Analyzers::from_yaml(fixture).unwrap();
-    let results = analyzers.by_filepath("test.json");
+    let results = analyzers.by_extension("test.json");
     assert_debug_snapshot!(results);
 }
 
@@ -30,7 +30,7 @@ fn test_simple() {
     );
     assert_debug_snapshot!(
         "analyzers_tests__test_simple__by_filepath",
-        analyzers.by_filepath("test.sh")
+        analyzers.by_extension("test.sh")
     );
     assert_debug_snapshot!(
         "analyzers_tests__test_simple",
@@ -99,5 +99,33 @@ fn test_pick_find_multiple() {
         language.name(),
         "JSON",
         "It should pick the language with the higher priority"
+    );
+}
+
+#[test]
+fn test_pick_filename() {
+    let fixture = fixture_str!("test_check_json_with_comments-analyzers.yaml");
+    let filepath = "devcontainer.json";
+    let contents = b"{}";
+    let analyzers = Analyzers::from_yaml(fixture).unwrap();
+    let language = analyzers.pick(filepath, contents, 1 << 20).unwrap();
+    assert_eq!(
+        language.name(),
+        "JSON with Comments",
+        "It should prioritize filename over extension."
+    );
+}
+
+#[test]
+fn test_pick_filepath_pattern() {
+    let fixture = fixture_str!("test_check_json_with_comments-analyzers.yaml");
+    let filepath = ".vscode/settings.json";
+    let contents = b"{}";
+    let analyzers = Analyzers::from_yaml(fixture).unwrap();
+    let language = analyzers.pick(filepath, contents, 1 << 20).unwrap();
+    assert_eq!(
+        language.name(),
+        "JSON with Comments",
+        "It should prioritize filepath pattern over extension."
     );
 }

--- a/gengo/tests/fixtures/test_check_json_with_comments-analyzers.yaml
+++ b/gengo/tests/fixtures/test_check_json_with_comments-analyzers.yaml
@@ -13,4 +13,8 @@ JSON with Comments:
     extensions:
     - json
     - jsonc
+    filenames:
+    - devcontainer.json
+    patterns:
+    - ".vscode/*.json"
   priority: 25


### PR DESCRIPTION
After checking shebangs, this prioritizes filenames first, then filepath patterns, then finally extensions.
