### PR TITLE
Add `Analysis::summary` method

### DIFF
--- a/gengo-bin/src/cli.rs
+++ b/gengo-bin/src/cli.rs
@@ -62,35 +62,19 @@ impl CLI {
             }
         };
 
-        let mut compiled = IndexMap::new();
-        let mut total = 0;
-        for (_, entry) in results.iter() {
-            if !(self.all || entry.detectable()) {
-                continue;
-            }
+        let summary = results.summary();
+        let total = summary.total();
+        let total = total as f64;
 
-            let language = entry.language();
-
-            let language_str = language.name();
-            let language_str = String::from(language_str);
-            let size = entry.size();
-
+        for (language, size) in summary.iter() {
+            let percentage = (size * 100) as f64 / total;
             #[cfg(feature = "color")]
             let color = language.owo_color().unwrap();
-
             #[cfg(not(feature = "color"))]
             let color = ();
 
-            let entry = compiled.entry(language_str).or_insert((0, color));
-            entry.0 += size;
-            total += size;
-        }
-
-        let total = total as f64;
-        for (language, (size, color)) in compiled.into_iter() {
-            let percentage = (size * 100) as f64 / total;
             let stats = format!("{:>6.2}% {}", percentage, size);
-            let line = format!("{:<15} {}", stats, language);
+            let line = format!("{:<15} {}", stats, language.name());
             let line = self.colorize(&line, color);
             writeln!(out, "{}", line)?;
         }

--- a/gengo/src/analysis/mod.rs
+++ b/gengo/src/analysis/mod.rs
@@ -3,6 +3,11 @@ use indexmap::map::Iter as IndexMapIter;
 use indexmap::IndexMap;
 use std::path::PathBuf;
 
+pub use summary::Iter as SummaryIter;
+pub use summary::Summary;
+
+mod summary;
+
 /// The result of analyzing a directory.
 #[derive(Debug)]
 pub struct Analysis(pub(super) IndexMap<PathBuf, Entry>);
@@ -10,6 +15,17 @@ pub struct Analysis(pub(super) IndexMap<PathBuf, Entry>);
 impl Analysis {
     pub fn iter(&self) -> Iter<'_> {
         Iter(self.0.iter())
+    }
+
+    /// Summarizes the analysis by language and size. Includes only
+    /// the entries that are detectable.
+    pub fn summary(&self) -> Summary {
+        let mut summary = IndexMap::new();
+        for entry in self.0.values().filter(|e| e.detectable()) {
+            let language = entry.language().clone();
+            *summary.entry(language).or_insert(0) += entry.size();
+        }
+        Summary(summary)
     }
 }
 

--- a/gengo/src/analysis/summary.rs
+++ b/gengo/src/analysis/summary.rs
@@ -1,0 +1,38 @@
+use crate::Language;
+use indexmap::map::Iter as IndexMapIter;
+use indexmap::IndexMap;
+
+/// The summary of an analysis.
+#[derive(Debug)]
+pub struct Summary(pub(super) IndexMap<Language, usize>);
+
+impl Summary {
+    /// Returns the total size of all languages.
+    pub fn total(&self) -> usize {
+        self.0.values().sum()
+    }
+
+    /// Returns an iterator over the languages and their sizes.
+    pub fn iter(&self) -> Iter<'_> {
+        Iter(self.0.iter())
+    }
+}
+
+pub struct Iter<'map>(IndexMapIter<'map, Language, usize>);
+
+impl<'map> Iterator for Iter<'map> {
+    type Item = (&'map Language, &'map usize);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+impl<'map> IntoIterator for &'map Summary {
+    type Item = (&'map Language, &'map usize);
+    type IntoIter = Iter<'map>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}

--- a/gengo/src/languages/mod.rs
+++ b/gengo/src/languages/mod.rs
@@ -9,7 +9,7 @@ mod matcher;
 const LANGUAGE_DEFINITIONS: &str = include_str!(concat!(env!("OUT_DIR"), "/languages.json"));
 
 /// A programming language.
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq)]
 pub struct Language {
     name: String,
     category: Category,
@@ -48,7 +48,7 @@ impl Language {
 }
 
 /// A category for a language.
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum Category {
     /// Data files. Examples: JSON, YAML, XML, CSV, etc.

--- a/gengo/src/lib.rs
+++ b/gengo/src/lib.rs
@@ -13,7 +13,7 @@ use std::error::Error;
 use std::path::{Path, PathBuf};
 use vendored::Vendored;
 
-mod analysis;
+pub mod analysis;
 mod builder;
 mod documentation;
 mod generated;


### PR DESCRIPTION
This adds a method to summarize the analysis results. Summaries will only include detectable
entries.
