### PR TITLE
Refactor `Gengo` to take generic `FileSource`

### DIFF
--- a/gengo/src/file_source/git.rs
+++ b/gengo/src/file_source/git.rs
@@ -1,0 +1,27 @@
+use super::FileSource;
+use std::path::Path;
+use std::error::Error;
+use git2::{AttrCheckFlags, AttrValue, Blob, Commit, ObjectType, Repository, Tree};
+
+pub struct Git {
+    repository: Repository,
+}
+
+impl<P: AsRef<Path>> FileSource<'bytes, P> for Git {
+    type Error = Box<dyn Error>;
+    type Iter = !; // TODO
+
+    fn open<Dir: AsRef<Path>>(path: Dir) -> Result<Self, Self::Error> {
+        let repository = Repository::open(path)?;
+        let git = Git { repository };
+        Ok(git)
+    }
+
+    fn iter(&self) -> Result<Self::Iter, Self::Error> {
+        todo!("Open revision and iterate over files")
+    }
+}
+
+pub struct Iter<'bytes> {
+    tree: Tree<'bytes>,
+}

--- a/gengo/src/file_source/mod.rs
+++ b/gengo/src/file_source/mod.rs
@@ -1,10 +1,16 @@
 use std::path::Path;
+pub use git::Git;
+
+mod git;
 
 /// A trait for a source of files.
 pub trait FileSource<'bytes, P: AsRef<Path>> {
+    type Error;
     type Iter: Iterator<Item = (P, &'bytes [u8])>;
     /// Opens the file source from the given directory.
-    fn open<DIR: AsRef<Path>>(path: DIR) -> Self;
+    fn open<Dir: AsRef<Path>>(path: Dir) -> Result<Self, Self::Error>
+    where
+        Self: Sized;
     /// Returns an iterator over the files in the source.
-    fn iter(&self) -> Self::Iter;
+    fn iter(&self) -> Result<Self::Iter, Self::Error>;
 }

--- a/gengo/src/file_source/mod.rs
+++ b/gengo/src/file_source/mod.rs
@@ -1,0 +1,10 @@
+use std::path::Path;
+
+/// A trait for a source of files.
+pub trait FileSource<'bytes, P: AsRef<Path>> {
+    type Iter: Iterator<Item = (P, &'bytes [u8])>;
+    /// Opens the file source from the given directory.
+    fn open<DIR: AsRef<Path>>(path: DIR) -> Self;
+    /// Returns an iterator over the files in the source.
+    fn iter(&self) -> Self::Iter;
+}

--- a/gengo/src/lib.rs
+++ b/gengo/src/lib.rs
@@ -27,7 +27,7 @@ mod documentation;
 mod generated;
 pub mod languages;
 mod vendored;
-mod file_source;
+pub mod file_source;
 
 /// Shared match options for consistent behavior.
 const GLOB_MATCH_OPTIONS: MatchOptions = MatchOptions {

--- a/gengo/src/lib.rs
+++ b/gengo/src/lib.rs
@@ -19,6 +19,7 @@ pub use languages::Language;
 use std::error::Error;
 use std::path::{Path, PathBuf};
 use vendored::Vendored;
+pub use file_source::FileSource;
 
 pub mod analysis;
 mod builder;
@@ -26,6 +27,7 @@ mod documentation;
 mod generated;
 pub mod languages;
 mod vendored;
+mod file_source;
 
 /// Shared match options for consistent behavior.
 const GLOB_MATCH_OPTIONS: MatchOptions = MatchOptions {


### PR DESCRIPTION
The main blocking issue right now is that Gengo opens git repositories to a specified rev. That's really specific to Git, and doesn't really work with generic file sources.

The git file source will need to take the rev (which probably makes more sense) instead of `Gengo` itself.

For #149
