### PR TITLE
Simplify error message for missing repository

### DIFF
--- a/gengo/src/builder.rs
+++ b/gengo/src/builder.rs
@@ -52,13 +52,11 @@ impl<P: AsRef<Path>> Builder<P> {
     pub fn build(self) -> Result<Gengo, Box<dyn ErrorTrait>> {
         let repository = match Repository::discover(self.repository_path) {
             Ok(r) => r,
-            Err(e) => {
-                match e.code() {
-                    ErrorCode::NotFound => {
-                        return Err(Box::new(Error::with_source(ErrorKind::NoRepository, e)));
-                    }
-                    _ => return Err(Box::new(e)),
+            Err(e) => match e.code() {
+                ErrorCode::NotFound => {
+                    return Err(Box::new(Error::with_source(ErrorKind::NoRepository, e)));
                 }
+                _ => return Err(Box::new(e)),
             },
         };
         let analyzers = self.analyzers.unwrap_or_default();

--- a/gengo/src/error.rs
+++ b/gengo/src/error.rs
@@ -1,0 +1,67 @@
+use std::fmt;
+use std::error::Error as ErrorTrait;
+
+macro_rules! error_kind {
+    ($($name:ident, $message:literal),*) => {
+        /// The kind of error that occurred.
+        #[derive(Debug)]
+        #[non_exhaustive]
+        pub enum ErrorKind {
+            $(
+                $name,
+            )*
+        }
+
+        impl fmt::Display for ErrorKind {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                match self {
+                    $(
+                        Self::$name => write!(f, $message),
+                    )*
+                }
+            }
+        }
+    };
+}
+
+error_kind!(NoRepository, "no repository found");
+
+impl ErrorTrait for ErrorKind {}
+
+#[derive(Debug)]
+pub struct Error {
+    kind: ErrorKind,
+    source: Option<Box<dyn ErrorTrait>>,
+}
+
+impl Error {
+    pub fn new(kind: ErrorKind) -> Self {
+        Self { kind, source: None }
+    }
+
+    pub fn with_source<E>(kind: ErrorKind, source: E) -> Self
+    where
+        E: ErrorTrait + 'static,
+    {
+        Self {
+            kind,
+            source: Some(Box::new(source)),
+        }
+    }
+
+    pub fn kind(&self) -> &ErrorKind {
+        &self.kind
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", &self.kind)
+    }
+}
+
+impl ErrorTrait for Error {
+    fn source(&self) -> Option<&(dyn ErrorTrait + 'static)> {
+        self.source.as_ref().map(|s| s.as_ref())
+    }
+}

--- a/gengo/src/error.rs
+++ b/gengo/src/error.rs
@@ -1,5 +1,5 @@
-use std::fmt;
 use std::error::Error as ErrorTrait;
+use std::fmt;
 
 macro_rules! error_kind {
     ($($name:ident, $message:literal),*) => {


### PR DESCRIPTION
This simplifies the error message by showing a custom message instead of
the message from the underlying git error.
