### PR TITLE
Add Jinja-like language

### DIFF
--- a/gengo/languages.yaml
+++ b/gengo/languages.yaml
@@ -349,6 +349,17 @@ JavaScript:
       - jsx
     interpreters:
       - node
+Jinja-like:
+  category: markup
+  color: "#A00000"
+  heuristics:
+    - "^\\{%\\sextends\\s"
+    - "\\{%\\s.+?\\s%\\}"
+  matchers:
+    extensions:
+      - html
+      - tera
+  priority: 25
 Jsonnet:
   category: programming
   color: "#0064BD"


### PR DESCRIPTION
This adds a language which is a combination of multiple languages that are extremely similar:
- Django templates
- Jinja
- Tera

And possibly more.

******

This language can possibly cause some confusion. It is very likely that a Jinja-like template will be detected as plain old HTML, since a template doesn't need any of its special syntax to be valid. While a template is often for HTML, and has the `.html` extension, it can be used for any language (onefetch and tokei use Tera to build Rust code).

In the reverse, it's possible that plain old HTML can be detected as a Jinja template. For example:
```html
<p>
  Django's templating language is cool! You use
</p>
<pre>
  {% for item in iterable %}
    {{ item }}
  {% endfor %}
</pre>
<p>
  to easily write items from a list.
</p>
```
    