### PR TITLE
Detect `.h` as C by default

### DIFF
--- a/gengo/languages.yaml
+++ b/gengo/languages.yaml
@@ -106,6 +106,7 @@ C:
     extensions:
       - c
       - h
+  priority: 75
 "C#":
   category: programming
   color: "#178600"


### PR DESCRIPTION
`C` and `C++` conflict over the `.h` file extension. This makes gengo
choose C when it can't decide if a `.h` file is C or C++.

Related: #65