### PR TITLE
Improve documentation detection

### DIFF
--- a/gengo/src/documentation.rs
+++ b/gengo/src/documentation.rs
@@ -29,10 +29,18 @@ impl Documentation {
     }
 
     fn globs() -> Vec<Pattern> {
-        ["**/docs/**"]
-            .into_iter()
-            .map(|g| Pattern::new(g).unwrap())
-            .collect()
+        [
+            // Directories
+            "**/docs/**",
+            // Files
+            "**/CHANGELOG",
+            "**/CHANGELOG.*",
+            "**/README",
+            "**/README.*",
+        ]
+        .into_iter()
+        .map(|g| Pattern::new(g).unwrap())
+        .collect()
     }
 }
 
@@ -48,7 +56,13 @@ mod tests {
         case("src/something.rs", false),
         case("docs/subfolder/something.md", true),
         case("", false),
-        case("docs", true)
+        case("docs", false),
+        case("CHANGELOG", true),
+        case("CHANGELOG.txt", true),
+        case("CHANGELOG.md", true),
+        case("README", true),
+        case("README.txt", true),
+        case("README.md", true)
     )]
     fn test_is_documentation_no_read(filepath: &str, expected: bool) {
         let documentation = Documentation::new();

--- a/gengo/src/documentation.rs
+++ b/gengo/src/documentation.rs
@@ -35,6 +35,8 @@ impl Documentation {
             // Files
             "**/CHANGELOG",
             "**/CHANGELOG.*",
+            "**/HACKING",
+            "**/HACKING.*",
             "**/README",
             "**/README.*",
         ]
@@ -60,6 +62,9 @@ mod tests {
         case("CHANGELOG", true),
         case("CHANGELOG.txt", true),
         case("CHANGELOG.md", true),
+        case("HACKING", true),
+        case("HACKING.txt", true),
+        case("HACKING.md", true),
         case("README", true),
         case("README.txt", true),
         case("README.md", true)

--- a/gengo/src/documentation.rs
+++ b/gengo/src/documentation.rs
@@ -1,10 +1,16 @@
+use super::GLOB_MATCH_OPTIONS;
+use glob::Pattern;
 use std::path::Path;
 
-pub struct Documentation;
+pub struct Documentation {
+    globs: Vec<Pattern>,
+}
 
 impl Documentation {
     pub fn new() -> Self {
-        Self
+        let globs = Self::globs();
+
+        Self { globs }
     }
 
     pub fn is_documentation<P: AsRef<Path>>(&self, filepath: P, contents: &[u8]) -> bool {
@@ -13,15 +19,20 @@ impl Documentation {
     }
 
     fn is_documentation_no_read<P: AsRef<Path>>(&self, filepath: P) -> bool {
-        filepath
-            .as_ref()
-            .components()
-            .next()
-            .map_or(false, |c| c.as_os_str() == "docs")
+        self.globs
+            .iter()
+            .any(|g| g.matches_path_with(filepath.as_ref(), GLOB_MATCH_OPTIONS))
     }
 
     fn is_documentation_with_read<P: AsRef<Path>>(&self, _filepath: P, _contents: &[u8]) -> bool {
         false
+    }
+
+    fn globs() -> Vec<Pattern> {
+        ["**/docs/**"]
+            .into_iter()
+            .map(|g| Pattern::new(g).unwrap())
+            .collect()
     }
 }
 


### PR DESCRIPTION
- Mark files in any `docs` directory as vendored
- Mar CHANGELOGs and READMEs as documentation
- Detect `HACKING.*` as documentation
