### PR TITLE
Make `Builder` take a `FileSource`

### DIFF
--- a/gengo/benches/run_on_self.rs
+++ b/gengo/benches/run_on_self.rs
@@ -1,21 +1,20 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use gengo::Builder;
+use gengo::{Builder, Git};
 
-fn head_benchmark(c: &mut Criterion) {
+fn git_benchmark(c: &mut Criterion) {
     let revs = {
         let mut revs: Vec<_> = (0..3).map(|n| format!("HEAD{}", "^".repeat(n))).collect();
         revs.extend_from_slice(&["test/javascript".into()]);
         revs
     };
     for rev in revs {
-        let gengo = Builder::new(env!("CARGO_MANIFEST_DIR"), &rev)
-            .build()
-            .unwrap();
+        let git = Git::new(env!("CARGO_MANIFEST_DIR"), &rev).unwrap();
+        let gengo = Builder::new(git).build().unwrap();
         c.bench_function(&format!("run on {}", rev), |b| {
             b.iter(|| gengo.analyze().unwrap())
         });
     }
 }
 
-criterion_group!(benches, head_benchmark);
+criterion_group!(benches, git_benchmark);
 criterion_main!(benches);

--- a/gengo/src/builder.rs
+++ b/gengo/src/builder.rs
@@ -8,13 +8,6 @@ use crate::file_source::FileSource;
 use std::error::Error as ErrorTrait;
 
 /// Builds a new `Gengo` instance.
-///
-/// # Example
-///
-/// ```no_run
-/// use gengo::Builder;
-/// let gengo = Builder::new("path/to/repo", "HEAD").build().unwrap();
-/// ```
 pub struct Builder<FS: for<'fs> FileSource<'fs>> {
     file_source: FS,
     analyzers: Option<Analyzers>,

--- a/gengo/src/lib.rs
+++ b/gengo/src/lib.rs
@@ -1,9 +1,20 @@
-//! Gengo is a language detection library for Git repositories.
+//! Gengo is a language detection library for collections of files.
+//! Currently, it supports reading from git repositories.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use gengo::{Builder, Git};
+//! let git = Git::new("path/to/repo", "HEAD").unwrap();
+//! let gengo = Builder::new(git).build().unwrap();
+//! let results = gengo.analyze().unwrap();
+//! ```
+//! # Built-in Languages
+//!
 //! While it is possible to provide your own definitions for
 //! language detection, Gengo comes with a set of built-in
 //! definitions.
 //!
-//! # Built-in Languages
 #![doc = include_str!(concat!(env!("OUT_DIR"), "/language-list.md"))]
 
 pub use analysis::Analysis;
@@ -13,7 +24,7 @@ use documentation::Documentation;
 pub use error::{Error, ErrorKind};
 use generated::Generated;
 
-pub use file_source::FileSource;
+pub use file_source::{FileSource, Git};
 use glob::MatchOptions;
 pub use languages::analyzer::Analyzers;
 use languages::Category;

--- a/gengo/tests/gengo_test.rs
+++ b/gengo/tests/gengo_test.rs
@@ -1,5 +1,4 @@
-use gengo::Analyzers;
-use gengo::Builder;
+use gengo::{Analyzers, Builder, Git};
 const ROOT: &str = env!("CARGO_MANIFEST_DIR");
 
 mod util;
@@ -10,10 +9,8 @@ fn test_javascript() {
     // guarantee order. Improve this test.
     let analyzers = fixture_str!("test_javascript-analyzers.yaml");
     let analyzers = Analyzers::from_yaml(analyzers).unwrap();
-    let gengo = Builder::new(ROOT, "test/javascript")
-        .analyzers(analyzers)
-        .build()
-        .unwrap();
+    let git = Git::new(ROOT, "test/javascript").unwrap();
+    let gengo = Builder::new(git).analyzers(analyzers).build().unwrap();
     let results = gengo.analyze().unwrap();
     insta::assert_debug_snapshot!(results);
 }


### PR DESCRIPTION
While this does not *provide* other file sources, it makes it possible to add them. Even external libraries can define their own file sources to be used, so this closes #149.