### PR TITLE
Stop cloning the index state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "gengo"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "criterion",
  "gix",
@@ -635,7 +635,7 @@ dependencies = [
 
 [[package]]
 name = "gengo-bin"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "clap",
  "gengo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 description = "Get the language distribution stats of your repository"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 repository = "https://github.com/spenserblack/gengo"
 readme = "README.md"


### PR DESCRIPTION
This drastically improves performance by no longer cloning the index
state, which only needs to be set once.

Resolves #197
Closes #199