### PR TITLE
Parallelize fetching file contents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "gengo"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "criterion",
  "gix",
@@ -635,7 +635,7 @@ dependencies = [
 
 [[package]]
 name = "gengo-bin"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "clap",
  "gengo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 description = "Get the language distribution stats of your repository"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2021"
 repository = "https://github.com/spenserblack/gengo"
 readme = "README.md"

--- a/gengo-bin/Cargo.toml
+++ b/gengo-bin/Cargo.toml
@@ -21,7 +21,7 @@ color = ["owo-colors", "gengo/owo-colors"]
 
 [dependencies]
 clap = { version = "4", features = ["derive", "wrap_help"] }
-gengo = { path = "../gengo", version = "0.7", default-features = false }
+gengo = { path = "../gengo", version = "0.8", default-features = false }
 indexmap = "2"
 owo-colors = { version = "3", optional = true }
 

--- a/gengo/src/file_source/mod.rs
+++ b/gengo/src/file_source/mod.rs
@@ -7,13 +7,20 @@ use std::path::Path;
 mod git;
 
 /// Provides files and overrides.
-pub trait FileSource<'files>: Send + Sync {
-    type Filepath: AsRef<Path> + Send + Sync;
-    type Contents: AsRef<[u8]> + Send + Sync;
-    type Iter: Iterator<Item = (Self::Filepath, Self::Contents)>;
+pub trait FileSource<'files>: Sync {
+    type Filepath: AsRef<Path>;
+    type Contents: AsRef<[u8]>;
+    type Entry: Send;
+    type Iter: Iterator<Item = Self::Entry> + Send;
 
-    /// Returns an iterator over the files.
-    fn files(&'files self) -> crate::Result<Self::Iter>;
+    /// Returns an iterator over the entries use to get filenames and contents.
+    fn entries(&'files self) -> crate::Result<Self::Iter>;
+
+    /// Gets a filename from an entry.
+    fn filepath(&'files self, entry: &Self::Entry) -> crate::Result<Self::Filepath>;
+
+    /// Gets file contents from an entry.
+    fn contents(&'files self, entry: &Self::Entry) -> crate::Result<Self::Contents>;
 
     /// Provides combined overrides for the file.
     fn overrides<O: AsRef<Path>>(&self, path: O) -> Overrides {

--- a/gengo/src/lib.rs
+++ b/gengo/src/lib.rs
@@ -35,7 +35,7 @@ use std::path::Path;
 
 use vendored::Vendored;
 
-use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
+use rayon::prelude::{ParallelBridge, ParallelIterator};
 
 pub mod analysis;
 mod builder;
@@ -69,14 +69,15 @@ pub struct Gengo<FS: for<'fs> FileSource<'fs>> {
 impl<FS: for<'fs> FileSource<'fs>> Gengo<FS> {
     /// Analyzes each file in the repository at the given revision.
     pub fn analyze(&self) -> Result<Analysis> {
-        // TODO Avoid this conversion to Vec?
-        let files: Vec<_> = self.file_source.files()?.collect();
-        // let mut entries = Vec::with_capacity(files.len());
-        let entries: Vec<(_, _)> = files
-            .par_iter()
-            .filter_map(|(path, contents)| {
-                let entry = self.analyze_blob(path, contents)?;
-                Some((path.as_ref().to_owned(), entry))
+        let entries: Vec<(_, _)> = self
+            .file_source
+            .entries()?
+            .par_bridge()
+            .filter_map(|entry| {
+                let filepath = self.file_source.filepath(&entry).ok()?;
+                let contents = self.file_source.contents(&entry).ok()?;
+                let entry = self.analyze_blob(&filepath, contents)?;
+                Some((filepath.as_ref().to_owned(), entry))
             })
             .collect();
 

--- a/gengo/tests/gengo_test.rs
+++ b/gengo/tests/gengo_test.rs
@@ -11,6 +11,8 @@ fn test_javascript() {
     let analyzers = Analyzers::from_yaml(analyzers).unwrap();
     let git = Git::new(ROOT, "test/javascript").unwrap();
     let gengo = Builder::new(git).analyzers(analyzers).build().unwrap();
-    let results = gengo.analyze().unwrap();
+    let analysis = gengo.analyze().unwrap();
+    let mut results: Vec<_> = analysis.iter().collect();
+    results.sort_by_key(|(path, _)| path);
     insta::assert_debug_snapshot!(results);
 }

--- a/gengo/tests/snapshots/gengo_test__javascript.snap
+++ b/gengo/tests/snapshots/gengo_test__javascript.snap
@@ -2,82 +2,80 @@
 source: gengo/tests/gengo_test.rs
 expression: results
 ---
-Analysis(
-    [
-        (
-            "bin.js",
-            Entry {
-                language: Language {
-                    name: "JavaScript",
-                    category: Programming,
-                    color: "#FFFF00",
-                },
-                size: 28,
-                detectable: true,
-                generated: false,
-                documentation: false,
-                vendored: false,
+[
+    (
+        "bin.js",
+        Entry {
+            language: Language {
+                name: "JavaScript",
+                category: Programming,
+                color: "#FFFF00",
             },
-        ),
-        (
-            "dist/bin.js",
-            Entry {
-                language: Language {
-                    name: "Plain Text",
-                    category: Prose,
-                    color: "#000000",
-                },
-                size: 62,
-                detectable: true,
-                generated: true,
-                documentation: false,
-                vendored: false,
+            size: 28,
+            detectable: true,
+            generated: false,
+            documentation: false,
+            vendored: false,
+        },
+    ),
+    (
+        "dist/bin.js",
+        Entry {
+            language: Language {
+                name: "Plain Text",
+                category: Prose,
+                color: "#000000",
             },
-        ),
-        (
-            "docs/index.html",
-            Entry {
-                language: Language {
-                    name: "HTML",
-                    category: Markup,
-                    color: "#FF4400",
-                },
-                size: 26,
-                detectable: false,
-                generated: false,
-                documentation: true,
-                vendored: false,
+            size: 62,
+            detectable: true,
+            generated: true,
+            documentation: false,
+            vendored: false,
+        },
+    ),
+    (
+        "docs/index.html",
+        Entry {
+            language: Language {
+                name: "HTML",
+                category: Markup,
+                color: "#FF4400",
             },
-        ),
-        (
-            "node_modules/my-dependency/index.js",
-            Entry {
-                language: Language {
-                    name: "JavaScript",
-                    category: Programming,
-                    color: "#FFFF00",
-                },
-                size: 29,
-                detectable: false,
-                generated: false,
-                documentation: false,
-                vendored: true,
+            size: 26,
+            detectable: false,
+            generated: false,
+            documentation: true,
+            vendored: false,
+        },
+    ),
+    (
+        "node_modules/my-dependency/index.js",
+        Entry {
+            language: Language {
+                name: "JavaScript",
+                category: Programming,
+                color: "#FFFF00",
             },
-        ),
-        (
-            "src/bin.ts",
-            Entry {
-                language: Language {
-                    name: "TypeScript",
-                    category: Programming,
-                    color: "#0000FF",
-                },
-                size: 62,
-                detectable: true,
-                generated: false,
-                documentation: false,
-                vendored: false,
+            size: 29,
+            detectable: false,
+            generated: false,
+            documentation: false,
+            vendored: true,
+        },
+    ),
+    (
+        "src/bin.ts",
+        Entry {
+            language: Language {
+                name: "TypeScript",
+                category: Programming,
+                color: "#0000FF",
             },
-        ),
-    ],
-)
+            size: 62,
+            detectable: true,
+            generated: false,
+            documentation: false,
+            vendored: false,
+        },
+    ),
+]


### PR DESCRIPTION
This changes the `FileSource` trait to iterate over generic `Entry`
types that can be reversed to `AsRef<Path>` and `AsRef<[u8]>`, instead
of iterating over the path and bytes directly. This allows the
potentially slow tasks of fetching the filepath and bytes from the entry
to be parallelized.

This also sorts analysis results in a snapshot test to make the tested value predictable.

Resolves #203
Closes #209