### PR TITLE
Sort CLI output by size *and* name

### DIFF
--- a/gengo-bin/src/cli.rs
+++ b/gengo-bin/src/cli.rs
@@ -75,7 +75,7 @@ impl CLI {
 
         let summary = {
             let mut summary: Vec<(_, _)> = summary.iter().collect();
-            summary.sort_by_key(|(_, size)| usize::MAX - *size);
+            summary.sort_by_key(|(language, size)| (usize::MAX - *size, language.name()));
             summary
         };
 


### PR DESCRIPTION
Before the CLI output was only sorted by size, which did not define the
ordering when 2 or more languages have the same size. This sorts by size
and then language name if the size is equal.
