### PR TITLE
Support GDScript

### DIFF
--- a/gengo/languages.yaml
+++ b/gengo/languages.yaml
@@ -278,6 +278,12 @@ Erlang:
       - f08
       - f90
       - f95
+GDScript:
+  category: programming
+  color: "#355570"
+  matchers:
+    extensions:
+      - gd
 GitHub Workflow:
   category: programming
   color: "#2088FF"


### PR DESCRIPTION
GDScript is a programming language built for the Godot game engine. ([docs](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_basics.html), [Wikipedia](https://en.wikipedia.org/wiki/Godot_(game_engine)#GDScript))

Example [output screenshot](https://github.com/spenserblack/gengo/assets/1126946/6d5d81eb-b023-4787-9320-edeff651aa3d).

Appears on #34 