### PR TITLE
Group file sources into subcommands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "gengo"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "criterion",
  "gix",
@@ -636,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "gengo-bin"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "clap",
  "gengo",
@@ -1773,7 +1773,7 @@ dependencies = [
 
 [[package]]
 name = "samples-test"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "gengo",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 description = "Get the language distribution stats of your repository"
-version = "0.8.2"
+version = "0.9.0"
 edition = "2021"
 repository = "https://github.com/spenserblack/gengo"
 readme = "README.md"

--- a/gengo-bin/Cargo.toml
+++ b/gengo-bin/Cargo.toml
@@ -21,7 +21,7 @@ color = ["gengo/owo-colors", "owo-colors"]
 
 [dependencies]
 clap = { version = "4", features = ["derive", "wrap_help"] }
-gengo = { path = "../gengo", version = "0.8", default-features = false }
+gengo = { path = "../gengo", version = "0.9", default-features = false }
 indexmap = "2"
 owo-colors = { version = "3", optional = true }
 

--- a/gengo-bin/tests/test_cli.rs
+++ b/gengo-bin/tests/test_cli.rs
@@ -28,27 +28,43 @@ macro_rules! assert_stdout_snapshot {
 #[test]
 #[cfg(not(feature = "color"))]
 fn test_javascript_repo() {
-    assert_stdout_snapshot!(&["gengo", "-r", "test/javascript", "-R", ROOT]);
+    assert_stdout_snapshot!(&["gengo", "git", "-r", "test/javascript", "-R", ROOT]);
 }
 
 #[test]
 #[cfg_attr(windows, ignore)]
 #[cfg(not(feature = "color"))]
 fn test_breakdown_javascript_repo() {
-    assert_stdout_snapshot!(&["gengo", "-r", "test/javascript", "-R", ROOT, "--breakdown"]);
+    assert_stdout_snapshot!(&[
+        "gengo",
+        "git",
+        "-r",
+        "test/javascript",
+        "-R",
+        ROOT,
+        "--breakdown"
+    ]);
 }
 
 #[test]
 #[cfg(feature = "color")]
 fn test_color_javascript_repo() {
-    assert_stdout_snapshot!(&["gengo", "-r", "test/javascript", "-R", ROOT]);
+    assert_stdout_snapshot!(&["gengo", "git", "-r", "test/javascript", "-R", ROOT]);
 }
 
 #[test]
 #[cfg_attr(windows, ignore)]
 #[cfg(feature = "color")]
 fn test_color_breakdown_javascript_repo() {
-    assert_stdout_snapshot!(&["gengo", "-r", "test/javascript", "-R", ROOT, "--breakdown"]);
+    assert_stdout_snapshot!(&[
+        "gengo",
+        "git",
+        "-r",
+        "test/javascript",
+        "-R",
+        ROOT,
+        "--breakdown"
+    ]);
 }
 
 //

--- a/gengo-bin/tests/test_cli.rs
+++ b/gengo-bin/tests/test_cli.rs
@@ -37,12 +37,12 @@ fn test_javascript_repo() {
 fn test_breakdown_javascript_repo() {
     assert_stdout_snapshot!(&[
         "gengo",
+        "--breakdown",
         "git",
         "-r",
         "test/javascript",
         "-R",
         ROOT,
-        "--breakdown"
     ]);
 }
 
@@ -58,12 +58,12 @@ fn test_color_javascript_repo() {
 fn test_color_breakdown_javascript_repo() {
     assert_stdout_snapshot!(&[
         "gengo",
+        "--breakdown",
         "git",
         "-r",
         "test/javascript",
         "-R",
         ROOT,
-        "--breakdown"
     ]);
 }
 

--- a/samples-test/Cargo.toml
+++ b/samples-test/Cargo.toml
@@ -10,4 +10,4 @@ license.workspace = true
 keywords.workspace = true
 
 [dependencies]
-gengo = { path = "../gengo", version = "0.8", default-features = false }
+gengo = { path = "../gengo", version = "0.9", default-features = false }


### PR DESCRIPTION
Each file source will have its own subcommand in the CLI. This makes it
easier to group options that are specific to file sources together.
