### PR TITLE
Allow release to be tested with Workflow Dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     tags: ["v*.*.*"]
+workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
@@ -10,6 +11,7 @@ env:
 jobs:
   publish:
     name: Publish
+    if: ${{ github.event_name != "workflow_dispatch" }}
     runs-on: ubuntu-latest
 
     steps:
@@ -22,6 +24,7 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: cargo publish -p gengo-bin
+
   github:
     name: GitHub Assets
     runs-on: ${{ matrix.os }}
@@ -42,12 +45,14 @@ jobs:
           cargo build --release
           tar -C target/release/ -czvf gengo-${{ runner.os }}-${{ runner.arch }}.tar.gz gengo${{ runner.os == 'Windows' && '.exe' || '' }}
       - name: Upload Assets
+        if: ${{ github.event_name != "workflow_dispatch" }}
         uses: softprops/action-gh-release@v1
         with:
           files: '*.tar.gz'
 
   docker:
     name: Publish Docker Image
+    if: ${{ github.event_name != "workflow_dispatch" }}
     runs-on: ubuntu-latest
     env:
       REGISTRY: ghcr.io

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags: ["v*.*.*"]
-workflow_dispatch:
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
This allows the release workflow to build github assets, but not publish
anything, through a workflow dispatch trigger. This should help assert
that assets can be built when updating build instructions.

For #244
