### PR TITLE
Upload release assets as artifacts for manual runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,11 +44,16 @@ jobs:
         run: |
           cargo build --release
           tar -C target/release/ -czvf gengo-${{ runner.os }}-${{ runner.arch }}.tar.gz gengo${{ runner.os == 'Windows' && '.exe' || '' }}
-      - name: Upload Assets
+      - name: Upload Release Assets
         if: ${{ github.event_name != 'workflow_dispatch' }}
         uses: softprops/action-gh-release@v1
         with:
           files: '*.tar.gz'
+      - name: Upload Artifacts
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: actions/upload-artifact@v3
+        with:
+          path: '*.tar.gz'
 
   docker:
     name: Publish Docker Image


### PR DESCRIPTION
When the release workflow is run manually, this uploads the built assets
as artifacts.
