### PR TITLE
Build codespace from Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,3 @@
+ARG VARIANT="1"
+FROM mcr.microsoft.com/devcontainers/rust:${VARIANT}
+RUN apt update && apt install -y cmake

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,9 @@
 {
   "name": "Rust",
-  "image": "mcr.microsoft.com/devcontainers/rust:1",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": { "VARIANT": "1" }
+  },
   "customizations": {
     "codespaces": {
       "openFiles": ["docs/CONTRIBUTING.md", "docs/HACKING.md", "gengo/languages.yaml"]


### PR DESCRIPTION
This builds from a dockerfile, installing `cmake` in the process.

Fixes #267.