### PR TITLE
Add support for NerdFont glyphs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,7 +611,7 @@ dependencies = [
 
 [[package]]
 name = "gengo"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "criterion",
  "gix",
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "gengo-bin"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "clap",
  "gengo",
@@ -1793,7 +1793,7 @@ dependencies = [
 
 [[package]]
 name = "samples-test"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "gengo",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1824,18 +1824,18 @@ checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1844,9 +1844,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
 dependencies = [
  "itoa",
  "ryu",
@@ -1855,9 +1855,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.33"
+version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0623d197252096520c6f2a5e1171ee436e5af99a5d7caa2891e55e61950e6d9"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
  "indexmap",
  "itoa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ serde_json = "1"
 
 [workspace.package]
 description = "Get the language distribution stats of your repository"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2021"
 repository = "https://github.com/spenserblack/gengo"
 readme = "README.md"

--- a/gengo-bin/tests/snapshots/test_cli__json_output_on_javascript_repo.snap
+++ b/gengo-bin/tests/snapshots/test_cli__json_output_on_javascript_repo.snap
@@ -10,7 +10,8 @@ expression: json
     "language": {
       "category": "programming",
       "color": "#F0DC4E",
-      "name": "JavaScript"
+      "name": "JavaScript",
+      "nerd_font_glyph": ""
     },
     "size": 28,
     "vendored": false
@@ -22,7 +23,8 @@ expression: json
     "language": {
       "category": "prose",
       "color": "#000000",
-      "name": "Plain Text"
+      "name": "Plain Text",
+      "nerd_font_glyph": null
     },
     "size": 62,
     "vendored": false
@@ -34,7 +36,8 @@ expression: json
     "language": {
       "category": "markup",
       "color": "#E96228",
-      "name": "HTML"
+      "name": "HTML",
+      "nerd_font_glyph": ""
     },
     "size": 26,
     "vendored": false
@@ -46,7 +49,8 @@ expression: json
     "language": {
       "category": "programming",
       "color": "#F0DC4E",
-      "name": "JavaScript"
+      "name": "JavaScript",
+      "nerd_font_glyph": ""
     },
     "size": 29,
     "vendored": true
@@ -58,7 +62,8 @@ expression: json
     "language": {
       "category": "programming",
       "color": "#2F74C0",
-      "name": "TypeScript"
+      "name": "TypeScript",
+      "nerd_font_glyph": ""
     },
     "size": 62,
     "vendored": false

--- a/gengo/languages.yaml
+++ b/gengo/languages.yaml
@@ -12,8 +12,8 @@
 #   # The color associated with the language.
 #   color:
 #
-#   # The icon associated with the language (optional).
-#   icon:
+#   # The Nerd Font glyph associated with the language (optional).
+#   nerd-font-glyph:
 #
 #   # Regexes unique to the contents of the file to resolve multiple matches. These will
 #   # be used if the matchers (see below) cannot narrow down a file to a single
@@ -53,7 +53,7 @@
 ".Env":
   category: data
   color: "#ECD53F"
-  icon: "\uf462" # 
+  nerd-font-glyph: "\uf462" # 
   matchers:
     extensions:
       - env
@@ -85,7 +85,7 @@ ATS:
 Ada:
   category: programming
   color: "#005A00"
-  icon: "\ue6b5" # 
+  nerd-font-glyph: "\ue6b5" # 
   matchers:
     extensions:
       - ada
@@ -94,14 +94,14 @@ Ada:
 Arduino:
   category: programming
   color: "#189BA1"
-  icon: "\uf34b" # 
+  nerd-font-glyph: "\uf34b" # 
   matchers:
     extensions:
       - ino
 Assembly:
   category: programming
   color: "#33AA33"
-  icon: "\ue266" # 
+  nerd-font-glyph: "\ue266" # 
   matchers:
     extensions:
       - asm
@@ -122,7 +122,7 @@ Batch File:
 C:
   category: programming
   color: "#8888CC"
-  icon: "\ue61e" # 
+  nerd-font-glyph: "\ue61e" # 
   matchers:
     extensions:
       - c
@@ -131,7 +131,7 @@ C:
 "C#":
   category: programming
   color: "#178600"
-  icon: "\uf031b" # 󰌛
+  nerd-font-glyph: "\uf031b" # 󰌛
   heuristics:
     - "^\\s*(using\\s+[A-Z][\\s\\w.]+;|namespace\\s*[\\w\\.]+\\s*(\\{|;)|\\/\\/)"
   matchers:
@@ -142,7 +142,7 @@ C:
 "C++":
   category: programming
   color: "#88CC88"
-  icon: "\ue61d" # 
+  nerd-font-glyph: "\ue61d" # 
   matchers:
     extensions:
       - c++
@@ -162,7 +162,7 @@ CMake:
 CSS:
   category: markup
   color: "#AA88AA"
-  icon: "\ue749" # 
+  nerd-font-glyph: "\ue749" # 
   matchers:
     extensions:
       - css
@@ -181,7 +181,7 @@ Ceylon:
 Clojure:
   category: programming
   color: "#77F212"
-  icon: "\ue76a" # 
+  nerd-font-glyph: "\ue76a" # 
   matchers:
     extensions:
       - clj
@@ -190,7 +190,7 @@ Clojure:
 CoffeeScript:
   category: programming
   color: "#C0FFEE"
-  icon: "\ue751" # 
+  nerd-font-glyph: "\ue751" # 
   matchers:
     extensions:
       - coffee
@@ -199,7 +199,7 @@ CoffeeScript:
 ColdFusion:
   category: programming
   color: "#001C57"
-  icon: "\ue645" # 
+  nerd-font-glyph: "\ue645" # 
   matchers:
     extensions:
       - cfm
@@ -212,7 +212,7 @@ Coq:
 Crystal:
   category: programming
   color: "#000000"
-  icon: "\ue62f" # 
+  nerd-font-glyph: "\ue62f" # 
   matchers:
     extensions:
       - cr
@@ -227,14 +227,14 @@ D:
 Dart:
   category: programming
   color: "#238BDA"
-  icon: "\ue64c" # 
+  nerd-font-glyph: "\ue64c" # 
   matchers:
     extensions:
       - dart
 Docker:
   category: programming
   color: "#2496ED"
-  icon: "\ue650" # 
+  nerd-font-glyph: "\ue650" # 
   matchers:
     filenames:
       - "Dockerfile"
@@ -243,7 +243,7 @@ Docker:
 Elixir:
   category: programming
   color: "#6B5674"
-  icon: "\ue62d" # 
+  nerd-font-glyph: "\ue62d" # 
   matchers:
     extensions:
       - ex
@@ -253,21 +253,21 @@ Elixir:
 Elm:
   category: programming
   color: "#1293D8"
-  icon: "\ue62c" # 
+  nerd-font-glyph: "\ue62c" # 
   matchers:
     extensions:
       - elm
 Emacs Lisp:
   category: programming
   color: "#7F5AB6"
-  icon: "\ue632" # 
+  nerd-font-glyph: "\ue632" # 
   matchers:
     extensions:
       - el
 Emojicode:
   category: programming
   color: "#FCEA2B"
-  icon: "\uf0785" # 󰞅
+  nerd-font-glyph: "\uf0785" # 󰞅
   matchers:
     extensions:
       - emojic
@@ -275,7 +275,7 @@ Emojicode:
 Erlang:
   category: programming
   color: "#A90433"
-  icon: "\ue7b1" # 
+  nerd-font-glyph: "\ue7b1" # 
   matchers:
     extensions:
       - erl
@@ -283,7 +283,7 @@ Erlang:
 "F#":
   category: programming
   color: "#F8008F"
-  icon: "\ue7a7" # 
+  nerd-font-glyph: "\ue7a7" # 
   matchers:
     extensions:
       - fs
@@ -291,7 +291,7 @@ Erlang:
 "FORTRAN Legacy":
   category: programming
   color: "#716152"
-  icon: "\uf121a" # 󱈚
+  nerd-font-glyph: "\uf121a" # 󱈚
   matchers:
     extensions:
       - f
@@ -302,7 +302,7 @@ Erlang:
 "Fortran Modern":
   category: programming
   color: "#725196"
-  icon: "\uf121a" # 󱈚
+  nerd-font-glyph: "\uf121a" # 󱈚
   matchers:
     extensions:
       - f03
@@ -312,7 +312,7 @@ Erlang:
 GDScript:
   category: programming
   color: "#355570"
-  icon: "\ue65f" # 
+  nerd-font-glyph: "\ue65f" # 
   matchers:
     extensions:
       - gd
@@ -327,21 +327,21 @@ GitHub Workflow:
 Go:
   category: programming
   color: "#00ADD8"
-  icon: "\ue627" # 
+  nerd-font-glyph: "\ue627" # 
   matchers:
     extensions:
       - go
 GraphQL:
   category: query
   color: "#E10098"
-  icon: "\uf0877" # 󰡷
+  nerd-font-glyph: "\uf0877" # 󰡷
   matchers:
     extensions:
       - graphql
 Groovy:
   category: programming
   color: "#4298B8"
-  icon: "\ue775" # 
+  nerd-font-glyph: "\ue775" # 
   matchers:
     extensions:
       - groovy
@@ -350,21 +350,21 @@ Groovy:
 HTML:
   category: markup
   color: "#E96228"
-  icon: "\ue736" # 
+  nerd-font-glyph: "\ue736" # 
   matchers:
     extensions:
       - html
 Haskell:
   category: programming
   color: "#5E5086"
-  icon: "\ue777" # 
+  nerd-font-glyph: "\ue777" # 
   matchers:
     extensions:
       - hs
 HolyC:
   category: programming
   color: "#FFFF00"
-  icon: "\ueebe" # 
+  nerd-font-glyph: "\ueebe" # 
   matchers:
     extensions:
       - hc
@@ -380,7 +380,7 @@ Ignore List:
 JSON:
   category: data
   color: "#AAAAAA"
-  icon: "\ueb0f" # 
+  nerd-font-glyph: "\ueb0f" # 
   matchers:
     extensions:
       - json
@@ -390,7 +390,7 @@ JSON:
 JSON with Comments:
   category: data
   color: "#CCCCCC"
-  icon: "\ueb0f" # 
+  nerd-font-glyph: "\ueb0f" # 
   heuristics:
     - "(?m)^\\s*/[/\\*]"
   matchers:
@@ -407,14 +407,14 @@ JSON with Comments:
 Java:
   category: programming
   color: "#5283A2"
-  icon: "\ue738" # 
+  nerd-font-glyph: "\ue738" # 
   matchers:
     extensions:
       - java
 JavaScript:
   category: programming
   color: "#F0DC4E"
-  icon: "\ue74e" # 
+  nerd-font-glyph: "\ue74e" # 
   matchers:
     extensions:
       - js
@@ -442,7 +442,7 @@ Jsonnet:
 Julia:
   category: programming
   color: "#9558B2"
-  icon: "\ue624" # 
+  nerd-font-glyph: "\ue624" # 
   matchers:
     extensions:
       - jl
@@ -455,7 +455,7 @@ Jupyter Notebook:
 Kotlin:
   category: programming
   color: "#7F52FF"
-  icon: "\ue634" # 
+  nerd-font-glyph: "\ue634" # 
   matchers:
     extensions:
       - kt
@@ -463,7 +463,7 @@ Kotlin:
 Lua:
   category: programming
   color: "#02027D"
-  icon: "\ue620" # 
+  nerd-font-glyph: "\ue620" # 
   matchers:
     extensions:
       - lua
@@ -472,7 +472,7 @@ Lua:
 Makefile:
   category: programming
   color: "#6B482F" # Arbitrary brown color representing a Gnu
-  icon: "\ue673" # 
+  nerd-font-glyph: "\ue673" # 
   matchers:
     filenames:
       - "Makefile"
@@ -481,7 +481,7 @@ Makefile:
 Markdown:
   category: prose
   color: "#03A7DD"
-  icon: "\ue73e" # 
+  nerd-font-glyph: "\ue73e" # 
   matchers:
     extensions:
       - markdown
@@ -496,21 +496,21 @@ Mermaid:
 Nim:
   category: programming
   color: "#ffe953"
-  icon: "\ue677" # 
+  nerd-font-glyph: "\ue677" # 
   matchers:
     extensions:
       - nim
 Nix:
   category: programming
   color: "#6898D3" # Average of the two colors in the logo
-  icon: "\uf313" # 
+  nerd-font-glyph: "\uf313" # 
   matchers:
     extensions:
       - nix
 OCaml:
   category: programming
   color: "#f48904"
-  icon: "\ue67a" # 
+  nerd-font-glyph: "\ue67a" # 
   matchers:
     extensions:
       - ml
@@ -524,14 +524,14 @@ Odin:
 PHP:
   category: programming
   color: "#7A86B8"
-  icon: "\ue608" # 
+  nerd-font-glyph: "\ue608" # 
   matchers:
     extensions:
       - php
 Perl:
   category: programming
   color: "#51547F"
-  icon: "\ue67e" # 
+  nerd-font-glyph: "\ue67e" # 
   matchers:
     extensions:
       - cow # cowsay files are Perl
@@ -551,7 +551,7 @@ Plain Text:
 PowerShell:
   category: programming
   color: "#012456"
-  icon: "\uf0a0a" # 󰨊
+  nerd-font-glyph: "\uf0a0a" # 󰨊
   matchers:
     extensions:
       - ps1
@@ -566,14 +566,14 @@ Pug:
 PureScript:
   category: programming
   color: "#1D222D"
-  icon: "\ue630" # 
+  nerd-font-glyph: "\ue630" # 
   matchers:
     extensions:
       - purs
 Python:
   category: programming
   color: "#3472A6"
-  icon: "\ue73c" # 
+  nerd-font-glyph: "\ue73c" # 
   matchers:
     extensions:
       - py
@@ -584,7 +584,7 @@ Python:
 Python Requirements File:
   category: data
   color: "#FFD342"
-  icon: "\ue73c" # 
+  nerd-font-glyph: "\ue73c" # 
   matchers:
     filenames:
       - "requirements.txt"
@@ -594,7 +594,7 @@ Python Requirements File:
 R:
   category: programming
   color: "#1F66B7" # Average of the two colors used in the logo gradient: https://www.r-project.org/logo/Rlogo.svg
-  icon: "\ue68a" # 
+  nerd-font-glyph: "\ue68a" # 
   matchers:
     extensions:
       - R
@@ -613,7 +613,7 @@ Regex:
 Ruby:
   category: programming
   color: "#D21304"
-  icon: "\ue23e" # 
+  nerd-font-glyph: "\ue23e" # 
   matchers:
     extensions:
       - gemspec
@@ -626,28 +626,28 @@ Ruby:
 Rust:
   category: programming
   color: "#DD3515"
-  icon: "\ue7a8" # 
+  nerd-font-glyph: "\ue7a8" # 
   matchers:
     extensions:
       - rs
 SQL:
   category: query
   color: "#FFBF1E"
-  icon: "\ue737" # 
+  nerd-font-glyph: "\ue737" # 
   matchers:
     extensions:
       - sql
 SVG:
   category: data
   color: "#FFB13B"
-  icon: "\uf0721" # 󰜡
+  nerd-font-glyph: "\uf0721" # 󰜡
   matchers:
     extensions:
       - svg
 Sass:
   category: markup
   color: "#CF649A"
-  icon: "\ue74b" # 
+  nerd-font-glyph: "\ue74b" # 
   # NOTE: Sass has two syntaxes. See https://sass-lang.com/guide/
   matchers:
     extensions:
@@ -656,7 +656,7 @@ Sass:
 Scheme:
   category: programming
   color: "#8800FF"
-  icon: "\ue6b1" # 
+  nerd-font-glyph: "\ue6b1" # 
   matchers:
     extensions:
       - scm
@@ -664,7 +664,7 @@ Scheme:
 Shell:
   category: programming
   color: "#262E28"
-  icon: "\uebca" # 
+  nerd-font-glyph: "\uebca" # 
   matchers:
     extensions:
       - bash
@@ -685,7 +685,7 @@ Solidity:
 Svelte:
   category: programming
   color: "#FF3E00"
-  icon: "\ue697" # 
+  nerd-font-glyph: "\ue697" # 
   matchers:
     extensions:
       - svelte
@@ -698,7 +698,7 @@ Swift:
 TOML:
   category: data
   color: "#9C4221"
-  icon: "\ue6b2" # 
+  nerd-font-glyph: "\ue6b2" # 
   matchers:
     extensions:
       - toml
@@ -714,7 +714,7 @@ TSV:
 TypeScript:
   category: programming
   color: "#2F74C0"
-  icon: "\ue628" # 
+  nerd-font-glyph: "\ue628" # 
   heuristics:
     - "(?m)^/// <reference "
     - "(?m)^export\\s+\\w[\\w\\d_]*?"
@@ -728,7 +728,7 @@ TypeScript:
 Vim Script:
   category: programming
   color: "#019833"
-  icon: "\ue62b" # 
+  nerd-font-glyph: "\ue62b" # 
   matchers:
     extensions:
       - vim
@@ -737,14 +737,14 @@ Vim Script:
 Vue:
   category: programming
   color: "#3FB27F"
-  icon: "\ue6a0" # 
+  nerd-font-glyph: "\ue6a0" # 
   matchers:
     extensions:
       - vue
 XML:
   category: data
   color: "#005FAF"
-  icon: "\uf05c0" # 󰗀
+  nerd-font-glyph: "\uf05c0" # 󰗀
   heuristics:
     - "<TS version=\"\\d+(?:\\.d+)+\" language=\""
   matchers:
@@ -757,7 +757,7 @@ XML:
 YAML:
   category: data
   color: "#CC1018"
-  icon: "\ue6a8" # 
+  nerd-font-glyph: "\ue6a8" # 
   matchers:
     extensions:
       - yaml
@@ -765,7 +765,7 @@ YAML:
 Zig:
   category: programming
   color: "#F7A41D"
-  icon: "\ue6a9" # 
+  nerd-font-glyph: "\ue6a9" # 
   matchers:
     extensions:
       - zig

--- a/gengo/languages.yaml
+++ b/gengo/languages.yaml
@@ -12,7 +12,7 @@
 #   # The color associated with the language.
 #   color:
 #
-#   # The icon associated with the language.
+#   # The icon associated with the language (optional).
 #   icon:
 #
 #   # Regexes unique to the contents of the file to resolve multiple matches. These will
@@ -64,21 +64,18 @@
 ABAP:
   category: programming
   color: "#3C3C3C"
-  icon: "" #
   matchers:
     extensions:
       - abap
 ABNF:
   category: data
   color: "#ABFABF"
-  icon: "" #
   matchers:
     extensions:
       - abnf
 ATS:
   category: programming
   color: "#0005FB"
-  icon: "" #
   matchers:
     extensions:
       - atxt
@@ -112,14 +109,12 @@ Assembly:
 AutoHotkey:
   category: programming
   color: "#334455"
-  icon: "" #
   matchers:
     extensions:
       - ahk
 Batch File:
   category: programming
   color: "#818B91"
-  icon: "" #
   matchers:
     extensions:
       - bat
@@ -159,7 +154,6 @@ C:
 CMake:
   category: programming
   color: "#CCCCCC"
-  icon: "" #
   matchers:
     extensions:
       - cmake
@@ -175,14 +169,12 @@ CSS:
 CSV:
   category: data
   color: "#1D6F42"
-  icon: "" #
   matchers:
     extensions:
       - csv
 Ceylon:
   category: programming
   color: "#F7941E"
-  icon: "" #
   matchers:
     extensions:
       - ceylon
@@ -214,7 +206,6 @@ ColdFusion:
 Coq:
   category: programming
   color: "#D0B68C"
-  icon: "" #
   matchers:
     extensions:
       - v
@@ -230,7 +221,6 @@ Crystal:
 D:
   category: programming
   color: "#B03931"
-  icon: "" #
   matchers:
     extensions:
       - d
@@ -329,7 +319,6 @@ GDScript:
 GitHub Workflow:
   category: programming
   color: "#2088FF"
-  icon: "" #
   matchers:
     patterns:
       - ".github/workflows/*.yaml"
@@ -382,7 +371,6 @@ HolyC:
 Ignore List:
   category: data
   color: "#330000"
-  icon: "" #
   matchers:
     filenames:
       - ".dockerignore"
@@ -436,7 +424,6 @@ JavaScript:
 Jinja-like:
   category: markup
   color: "#A00000"
-  icon: "" #
   heuristics:
     - "^\\{%\\sextends\\s"
     - "\\{%\\s.+?\\s%\\}"
@@ -448,7 +435,6 @@ Jinja-like:
 Jsonnet:
   category: programming
   color: "#0064BD"
-  icon: "" #
   matchers:
     extensions:
       - jsonnet
@@ -463,7 +449,6 @@ Julia:
 Jupyter Notebook:
   category: markup
   color: "#F37726"
-  icon: "" #
   matchers:
     extensions:
       - ipynb
@@ -504,7 +489,6 @@ Markdown:
 Mermaid:
   category: markup
   color: "#FF3670"
-  icon: "" #
   matchers:
     extensions:
       - mermaid
@@ -534,7 +518,6 @@ OCaml:
 Odin:
   category: programming
   color: "#3882D2"
-  icon: "" #
   matchers:
     extensions:
       - odin
@@ -558,7 +541,6 @@ Perl:
 Plain Text:
   category: prose
   color: "#000000"
-  icon: "" #
   matchers:
     extensions:
       - text
@@ -578,7 +560,6 @@ PowerShell:
 Pug:
   category: markup
   color: "#A86454"
-  icon: "" #
   matchers:
     extensions:
       - pug
@@ -620,14 +601,12 @@ R:
 Regex:
   category: data
   color: "#44E03F"
-  icon: "" #
   matchers:
     extensions:
       - regex
 "Ren'Py":
   category: programming
   color: "#FF7F7F"
-  icon: "" #
   matchers:
     extensions:
       - rpy
@@ -700,7 +679,6 @@ Shell:
 Solidity:
   category: programming
   color: "#2B247C"
-  icon: "" #
   matchers:
     extensions:
       - sol
@@ -714,7 +692,6 @@ Svelte:
 Swift:
   category: programming
   color: "#DC5114"
-  icon: "" #
   matchers:
     extensions:
       - swift
@@ -731,7 +708,6 @@ TOML:
 TSV:
   category: data
   color: "#1D6F42"
-  icon: "" #
   matchers:
     extensions:
       - tsv

--- a/gengo/languages.yaml
+++ b/gengo/languages.yaml
@@ -53,7 +53,7 @@
 ".Env":
   category: data
   color: "#ECD53F"
-  nerd-font-glyph: "\uf462" # 
+  nerd-font-glyph: "\uf462"
   matchers:
     extensions:
       - env
@@ -85,7 +85,7 @@ ATS:
 Ada:
   category: programming
   color: "#005A00"
-  nerd-font-glyph: "\ue6b5" # 
+  nerd-font-glyph: "\ue6b5"
   matchers:
     extensions:
       - ada
@@ -94,14 +94,14 @@ Ada:
 Arduino:
   category: programming
   color: "#189BA1"
-  nerd-font-glyph: "\uf34b" # 
+  nerd-font-glyph: "\uf34b"
   matchers:
     extensions:
       - ino
 Assembly:
   category: programming
   color: "#33AA33"
-  nerd-font-glyph: "\ue266" # 
+  nerd-font-glyph: "\ue266"
   matchers:
     extensions:
       - asm
@@ -122,7 +122,7 @@ Batch File:
 C:
   category: programming
   color: "#8888CC"
-  nerd-font-glyph: "\ue61e" # 
+  nerd-font-glyph: "\ue61e"
   matchers:
     extensions:
       - c
@@ -131,7 +131,7 @@ C:
 "C#":
   category: programming
   color: "#178600"
-  nerd-font-glyph: "\uf031b" # 󰌛
+  nerd-font-glyph: "\uf031b"
   heuristics:
     - "^\\s*(using\\s+[A-Z][\\s\\w.]+;|namespace\\s*[\\w\\.]+\\s*(\\{|;)|\\/\\/)"
   matchers:
@@ -142,7 +142,7 @@ C:
 "C++":
   category: programming
   color: "#88CC88"
-  nerd-font-glyph: "\ue61d" # 
+  nerd-font-glyph: "\ue61d"
   matchers:
     extensions:
       - c++
@@ -162,7 +162,7 @@ CMake:
 CSS:
   category: markup
   color: "#AA88AA"
-  nerd-font-glyph: "\ue749" # 
+  nerd-font-glyph: "\ue749"
   matchers:
     extensions:
       - css
@@ -181,7 +181,7 @@ Ceylon:
 Clojure:
   category: programming
   color: "#77F212"
-  nerd-font-glyph: "\ue76a" # 
+  nerd-font-glyph: "\ue76a"
   matchers:
     extensions:
       - clj
@@ -190,7 +190,7 @@ Clojure:
 CoffeeScript:
   category: programming
   color: "#C0FFEE"
-  nerd-font-glyph: "\ue751" # 
+  nerd-font-glyph: "\ue751"
   matchers:
     extensions:
       - coffee
@@ -199,7 +199,7 @@ CoffeeScript:
 ColdFusion:
   category: programming
   color: "#001C57"
-  nerd-font-glyph: "\ue645" # 
+  nerd-font-glyph: "\ue645"
   matchers:
     extensions:
       - cfm
@@ -212,7 +212,7 @@ Coq:
 Crystal:
   category: programming
   color: "#000000"
-  nerd-font-glyph: "\ue62f" # 
+  nerd-font-glyph: "\ue62f"
   matchers:
     extensions:
       - cr
@@ -227,14 +227,14 @@ D:
 Dart:
   category: programming
   color: "#238BDA"
-  nerd-font-glyph: "\ue64c" # 
+  nerd-font-glyph: "\ue64c"
   matchers:
     extensions:
       - dart
 Docker:
   category: programming
   color: "#2496ED"
-  nerd-font-glyph: "\ue650" # 
+  nerd-font-glyph: "\ue650"
   matchers:
     filenames:
       - "Dockerfile"
@@ -243,7 +243,7 @@ Docker:
 Elixir:
   category: programming
   color: "#6B5674"
-  nerd-font-glyph: "\ue62d" # 
+  nerd-font-glyph: "\ue62d"
   matchers:
     extensions:
       - ex
@@ -253,21 +253,21 @@ Elixir:
 Elm:
   category: programming
   color: "#1293D8"
-  nerd-font-glyph: "\ue62c" # 
+  nerd-font-glyph: "\ue62c"
   matchers:
     extensions:
       - elm
 Emacs Lisp:
   category: programming
   color: "#7F5AB6"
-  nerd-font-glyph: "\ue632" # 
+  nerd-font-glyph: "\ue632"
   matchers:
     extensions:
       - el
 Emojicode:
   category: programming
   color: "#FCEA2B"
-  nerd-font-glyph: "\uf0785" # 󰞅
+  nerd-font-glyph: "\uf0785"
   matchers:
     extensions:
       - emojic
@@ -275,7 +275,7 @@ Emojicode:
 Erlang:
   category: programming
   color: "#A90433"
-  nerd-font-glyph: "\ue7b1" # 
+  nerd-font-glyph: "\ue7b1"
   matchers:
     extensions:
       - erl
@@ -283,7 +283,7 @@ Erlang:
 "F#":
   category: programming
   color: "#F8008F"
-  nerd-font-glyph: "\ue7a7" # 
+  nerd-font-glyph: "\ue7a7"
   matchers:
     extensions:
       - fs
@@ -291,7 +291,7 @@ Erlang:
 "FORTRAN Legacy":
   category: programming
   color: "#716152"
-  nerd-font-glyph: "\uf121a" # 󱈚
+  nerd-font-glyph: "\uf121a"
   matchers:
     extensions:
       - f
@@ -302,7 +302,7 @@ Erlang:
 "Fortran Modern":
   category: programming
   color: "#725196"
-  nerd-font-glyph: "\uf121a" # 󱈚
+  nerd-font-glyph: "\uf121a"
   matchers:
     extensions:
       - f03
@@ -312,7 +312,7 @@ Erlang:
 GDScript:
   category: programming
   color: "#355570"
-  nerd-font-glyph: "\ue65f" # 
+  nerd-font-glyph: "\ue65f"
   matchers:
     extensions:
       - gd
@@ -327,21 +327,21 @@ GitHub Workflow:
 Go:
   category: programming
   color: "#00ADD8"
-  nerd-font-glyph: "\ue627" # 
+  nerd-font-glyph: "\ue627"
   matchers:
     extensions:
       - go
 GraphQL:
   category: query
   color: "#E10098"
-  nerd-font-glyph: "\uf0877" # 󰡷
+  nerd-font-glyph: "\uf0877"
   matchers:
     extensions:
       - graphql
 Groovy:
   category: programming
   color: "#4298B8"
-  nerd-font-glyph: "\ue775" # 
+  nerd-font-glyph: "\ue775"
   matchers:
     extensions:
       - groovy
@@ -350,21 +350,21 @@ Groovy:
 HTML:
   category: markup
   color: "#E96228"
-  nerd-font-glyph: "\ue736" # 
+  nerd-font-glyph: "\ue736"
   matchers:
     extensions:
       - html
 Haskell:
   category: programming
   color: "#5E5086"
-  nerd-font-glyph: "\ue777" # 
+  nerd-font-glyph: "\ue777"
   matchers:
     extensions:
       - hs
 HolyC:
   category: programming
   color: "#FFFF00"
-  nerd-font-glyph: "\ueebe" # 
+  nerd-font-glyph: "\ueebe"
   matchers:
     extensions:
       - hc
@@ -380,7 +380,7 @@ Ignore List:
 JSON:
   category: data
   color: "#AAAAAA"
-  nerd-font-glyph: "\ueb0f" # 
+  nerd-font-glyph: "\ueb0f"
   matchers:
     extensions:
       - json
@@ -390,7 +390,7 @@ JSON:
 JSON with Comments:
   category: data
   color: "#CCCCCC"
-  nerd-font-glyph: "\ueb0f" # 
+  nerd-font-glyph: "\ueb0f"
   heuristics:
     - "(?m)^\\s*/[/\\*]"
   matchers:
@@ -407,14 +407,14 @@ JSON with Comments:
 Java:
   category: programming
   color: "#5283A2"
-  nerd-font-glyph: "\ue738" # 
+  nerd-font-glyph: "\ue738"
   matchers:
     extensions:
       - java
 JavaScript:
   category: programming
   color: "#F0DC4E"
-  nerd-font-glyph: "\ue74e" # 
+  nerd-font-glyph: "\ue74e"
   matchers:
     extensions:
       - js
@@ -442,7 +442,7 @@ Jsonnet:
 Julia:
   category: programming
   color: "#9558B2"
-  nerd-font-glyph: "\ue624" # 
+  nerd-font-glyph: "\ue624"
   matchers:
     extensions:
       - jl
@@ -455,7 +455,7 @@ Jupyter Notebook:
 Kotlin:
   category: programming
   color: "#7F52FF"
-  nerd-font-glyph: "\ue634" # 
+  nerd-font-glyph: "\ue634"
   matchers:
     extensions:
       - kt
@@ -463,7 +463,7 @@ Kotlin:
 Lua:
   category: programming
   color: "#02027D"
-  nerd-font-glyph: "\ue620" # 
+  nerd-font-glyph: "\ue620"
   matchers:
     extensions:
       - lua
@@ -472,7 +472,7 @@ Lua:
 Makefile:
   category: programming
   color: "#6B482F" # Arbitrary brown color representing a Gnu
-  nerd-font-glyph: "\ue673" # 
+  nerd-font-glyph: "\ue673"
   matchers:
     filenames:
       - "Makefile"
@@ -481,7 +481,7 @@ Makefile:
 Markdown:
   category: prose
   color: "#03A7DD"
-  nerd-font-glyph: "\ue73e" # 
+  nerd-font-glyph: "\ue73e"
   matchers:
     extensions:
       - markdown
@@ -496,21 +496,21 @@ Mermaid:
 Nim:
   category: programming
   color: "#ffe953"
-  nerd-font-glyph: "\ue677" # 
+  nerd-font-glyph: "\ue677"
   matchers:
     extensions:
       - nim
 Nix:
   category: programming
   color: "#6898D3" # Average of the two colors in the logo
-  nerd-font-glyph: "\uf313" # 
+  nerd-font-glyph: "\uf313"
   matchers:
     extensions:
       - nix
 OCaml:
   category: programming
   color: "#f48904"
-  nerd-font-glyph: "\ue67a" # 
+  nerd-font-glyph: "\ue67a"
   matchers:
     extensions:
       - ml
@@ -524,14 +524,14 @@ Odin:
 PHP:
   category: programming
   color: "#7A86B8"
-  nerd-font-glyph: "\ue608" # 
+  nerd-font-glyph: "\ue608"
   matchers:
     extensions:
       - php
 Perl:
   category: programming
   color: "#51547F"
-  nerd-font-glyph: "\ue67e" # 
+  nerd-font-glyph: "\ue67e"
   matchers:
     extensions:
       - cow # cowsay files are Perl
@@ -551,7 +551,7 @@ Plain Text:
 PowerShell:
   category: programming
   color: "#012456"
-  nerd-font-glyph: "\uf0a0a" # 󰨊
+  nerd-font-glyph: "\uf0a0a"
   matchers:
     extensions:
       - ps1
@@ -566,14 +566,14 @@ Pug:
 PureScript:
   category: programming
   color: "#1D222D"
-  nerd-font-glyph: "\ue630" # 
+  nerd-font-glyph: "\ue630"
   matchers:
     extensions:
       - purs
 Python:
   category: programming
   color: "#3472A6"
-  nerd-font-glyph: "\ue73c" # 
+  nerd-font-glyph: "\ue73c"
   matchers:
     extensions:
       - py
@@ -584,7 +584,7 @@ Python:
 Python Requirements File:
   category: data
   color: "#FFD342"
-  nerd-font-glyph: "\ue73c" # 
+  nerd-font-glyph: "\ue73c"
   matchers:
     filenames:
       - "requirements.txt"
@@ -594,7 +594,7 @@ Python Requirements File:
 R:
   category: programming
   color: "#1F66B7" # Average of the two colors used in the logo gradient: https://www.r-project.org/logo/Rlogo.svg
-  nerd-font-glyph: "\ue68a" # 
+  nerd-font-glyph: "\ue68a"
   matchers:
     extensions:
       - R
@@ -613,7 +613,7 @@ Regex:
 Ruby:
   category: programming
   color: "#D21304"
-  nerd-font-glyph: "\ue23e" # 
+  nerd-font-glyph: "\ue23e"
   matchers:
     extensions:
       - gemspec
@@ -626,28 +626,28 @@ Ruby:
 Rust:
   category: programming
   color: "#DD3515"
-  nerd-font-glyph: "\ue7a8" # 
+  nerd-font-glyph: "\ue7a8"
   matchers:
     extensions:
       - rs
 SQL:
   category: query
   color: "#FFBF1E"
-  nerd-font-glyph: "\ue737" # 
+  nerd-font-glyph: "\ue737"
   matchers:
     extensions:
       - sql
 SVG:
   category: data
   color: "#FFB13B"
-  nerd-font-glyph: "\uf0721" # 󰜡
+  nerd-font-glyph: "\uf0721"
   matchers:
     extensions:
       - svg
 Sass:
   category: markup
   color: "#CF649A"
-  nerd-font-glyph: "\ue74b" # 
+  nerd-font-glyph: "\ue74b"
   # NOTE: Sass has two syntaxes. See https://sass-lang.com/guide/
   matchers:
     extensions:
@@ -656,7 +656,7 @@ Sass:
 Scheme:
   category: programming
   color: "#8800FF"
-  nerd-font-glyph: "\ue6b1" # 
+  nerd-font-glyph: "\ue6b1"
   matchers:
     extensions:
       - scm
@@ -664,7 +664,7 @@ Scheme:
 Shell:
   category: programming
   color: "#262E28"
-  nerd-font-glyph: "\uebca" # 
+  nerd-font-glyph: "\uebca"
   matchers:
     extensions:
       - bash
@@ -685,7 +685,7 @@ Solidity:
 Svelte:
   category: programming
   color: "#FF3E00"
-  nerd-font-glyph: "\ue697" # 
+  nerd-font-glyph: "\ue697"
   matchers:
     extensions:
       - svelte
@@ -698,7 +698,7 @@ Swift:
 TOML:
   category: data
   color: "#9C4221"
-  nerd-font-glyph: "\ue6b2" # 
+  nerd-font-glyph: "\ue6b2"
   matchers:
     extensions:
       - toml
@@ -714,7 +714,7 @@ TSV:
 TypeScript:
   category: programming
   color: "#2F74C0"
-  nerd-font-glyph: "\ue628" # 
+  nerd-font-glyph: "\ue628"
   heuristics:
     - "(?m)^/// <reference "
     - "(?m)^export\\s+\\w[\\w\\d_]*?"
@@ -728,7 +728,7 @@ TypeScript:
 Vim Script:
   category: programming
   color: "#019833"
-  nerd-font-glyph: "\ue62b" # 
+  nerd-font-glyph: "\ue62b"
   matchers:
     extensions:
       - vim
@@ -737,14 +737,14 @@ Vim Script:
 Vue:
   category: programming
   color: "#3FB27F"
-  nerd-font-glyph: "\ue6a0" # 
+  nerd-font-glyph: "\ue6a0"
   matchers:
     extensions:
       - vue
 XML:
   category: data
   color: "#005FAF"
-  nerd-font-glyph: "\uf05c0" # 󰗀
+  nerd-font-glyph: "\uf05c0"
   heuristics:
     - "<TS version=\"\\d+(?:\\.d+)+\" language=\""
   matchers:
@@ -757,7 +757,7 @@ XML:
 YAML:
   category: data
   color: "#CC1018"
-  nerd-font-glyph: "\ue6a8" # 
+  nerd-font-glyph: "\ue6a8"
   matchers:
     extensions:
       - yaml
@@ -765,7 +765,7 @@ YAML:
 Zig:
   category: programming
   color: "#F7A41D"
-  nerd-font-glyph: "\ue6a9" # 
+  nerd-font-glyph: "\ue6a9"
   matchers:
     extensions:
       - zig

--- a/gengo/src/language/mod.rs
+++ b/gengo/src/language/mod.rs
@@ -180,6 +180,7 @@ impl Language {
             name: self.name(),
             category: self.category(),
             color: self.color(),
+            nerd_font_glyph: self.nerd_font_glyph(),
         }
     }
 }
@@ -245,6 +246,7 @@ struct Serialize {
     name: &'static str,
     category: Category,
     color: &'static str,
+    nerd_font_glyph: Option<&'static str>,
 }
 
 #[cfg(test)]

--- a/gengo/src/language/mod.rs
+++ b/gengo/src/language/mod.rs
@@ -16,6 +16,7 @@ _include!("category_mixin.rs");
 _include!("name_mixin.rs");
 _include!("parse_variant_mixin.rs");
 _include!("color_mixin.rs");
+_include!("nerd_font_glyph_mixin.rs");
 _include!("priority_mixin.rs");
 _include!("from_extension_mixin.rs");
 _include!("from_filename_mixin.rs");


### PR DESCRIPTION
Resolves #341

# To do

- [x] Rename `icon` to `nerd-font-glyph` (or something else that's namespaced to Nerd Fonts)
- [x] Make entry optional (no empty strings)
- [x] Add fn to get Nerd Font glyph

# After merge

- [ ] Merge #349