### PR TITLE
Refactor generated code to be multiple smaller files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,7 +621,6 @@ dependencies = [
  "insta",
  "once_cell",
  "owo-colors",
- "prettyplease",
  "proc-macro2",
  "quote",
  "rayon",
@@ -630,7 +629,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "syn",
 ]
 
 [[package]]
@@ -1631,16 +1629,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
 dependencies = [
  "plotters-backend",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac2cf0f2e4f42b49f5ffd07dae8d746508ef7526c13940e5f524012ae6c6550"
-dependencies = [
- "proc-macro2",
- "syn",
 ]
 
 [[package]]

--- a/gengo/Cargo.toml
+++ b/gengo/Cargo.toml
@@ -34,11 +34,9 @@ serde = { version = "1", features = ["derive"] }
 
 [build-dependencies]
 indexmap = { version = "2", features = ["serde"] }
-prettyplease = "0.2"
 proc-macro2 = "1"
 serde_json.workspace = true
 serde_yaml = "0.9"
-syn = "2"
 quote = "1"
 
 [dev-dependencies]


### PR DESCRIPTION
Instead of generating one file with all of the data, this makes them
more like mixins, breaking up the code/tokens into smaller pieces to be
included.
