### PR TITLE
Add astro support

### DIFF
--- a/gengo/languages.yaml
+++ b/gengo/languages.yaml
@@ -106,6 +106,12 @@ Assembly:
     extensions:
       - asm
       - s
+Astro:
+  category: programming
+  color: "#FF5A1D"
+  matchers:
+    extensions:
+      - astro
 AutoHotkey:
   category: programming
   color: "#334455"


### PR DESCRIPTION
 This PR add astro support: https://astro.build
 Mentioned in #34 
 
 - [x] If this language conflicts with another language (same extension), I've added heuristics
 - [x] If this language conflicts with another language, I've linked to the pull request that added the other language here: