### PR TITLE
Use grcov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     needs:
       - lint
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         os:
           - macOS-latest
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Fetch Test Branches
         run: git fetch origin test/javascript:test/javascript
-      - name: Main Cache
+      - name: Cache
         uses: actions/cache@v4
         with:
           path: |
@@ -45,24 +45,63 @@ jobs:
       - name: Test
         run: cargo test --verbose ${{ matrix.feature-flags }}
 
-      # TODO: Make it easier to use a new cache when updating bin versions
-      - name: Bin Cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-          key: ${{ runner.os }}-cargo-bin
-      - name: Install tarpaulin
-        run: cargo install cargo-tarpaulin@0.27.0
-        # NOTE: The last step fails if tarpaulin is already installed
-        continue-on-error: true
-      - name: Generate Coverage
-        run: cargo tarpaulin --verbose ${{ matrix.feature-flags }} --workspace --timeout 120 --out xml
-      - name: Upload Coverage
-        uses: codecov/codecov-action@v4
-        with:
-          flags: ${{ matrix.os }},${{ matrix.feature-flags }}
-          token: ${{ secrets.CODECOV_TOKEN }}
+  coverage:
+    name: Coverage ${{ matrix.feature-flags }} (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    needs:
+      - build
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macOS-latest
+          - ubuntu-latest
+          - windows-latest
+        feature-flags:
+          - --no-default-features
+          - --no-default-features --features color
+    env:
+      GRCOV_VERSION: "0.8.19"
+      RUSTFLAGS: "-Cinstrument-coverage"
+      LLVM_PROFILE_FILE: "coverage.profraw"
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Fetch Test Branches
+      run: git fetch origin test/javascript:test/javascript
+    - name: Main Cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - name: Bin Cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/bin/
+        key: ${{ runner.os }}-cargo-bin-grcov-${{ env.GRCOV_VERSION }}
+    - name: Install grcov
+      run: cargo install "grcov@$GRCOV_VERSION"
+      shell: bash
+      # NOTE: The last step fails if grcov is already installed
+      continue-on-error: true
+    - name: Build
+      run: cargo build
+    - name: Test
+      run: cargo test
+    - name: Run grcov
+      run: grcov . --llvm --output-types lcov --output-path lcov.info --source-dir . --service-name "$GITHUB_WORKFLOW" --commit-sha "$GITHUB_SHA" --binary-path ./target/debug
+      shell: bash
+    - name: Upload Coverage
+      uses: codecov/codecov-action@v4
+      with:
+        flags: ${{ matrix.os }},${{ matrix.feature-flags }}
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: true
 
   lint:
     name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,16 +79,16 @@ jobs:
           target/
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Bin Cache
+      id: bin-cache
       uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/bin/
         key: ${{ runner.os }}-cargo-bin-grcov-${{ env.GRCOV_VERSION }}
     - name: Install grcov
+      if: steps.bin-cache.outputs.cache-hit != 'true'
       run: cargo install "grcov@$GRCOV_VERSION"
       shell: bash
-      # NOTE: The last step fails if grcov is already installed
-      continue-on-error: true
     - name: Build
       run: cargo build
     - name: Test


### PR DESCRIPTION
This switches from `cargo tarpaulin` to using `grcov`. Because grcov
requires certain `RUSTFLAGS` to be set, it has been separated into a
different job.

References:
- https://github.com/mozilla/grcov?tab=readme-ov-file#example-how-to-generate-source-based-coverage-for-a-rust-project
- https://github.com/codecov/example-rust
- https://github.com/actions-rs/grcov

To do:
- [ ] Skip install [specifically on a cache hit](https://github.com/actions/cache?tab=readme-ov-file#outputs)
