### PR TITLE
Raise Perl's priority

### DIFF
--- a/gengo/languages.yaml
+++ b/gengo/languages.yaml
@@ -643,6 +643,7 @@ Perl:
       - pl
     interpreters:
       - perl
+  priority: 75
 Plain Text:
   category: prose
   color: "#000000"


### PR DESCRIPTION
Perl shares the `.pl` extension with Raku (Raku used to be Perl 6). This
should ensure that Perl gets picked when it can't be determined if a
`*.pl` file is Perl or Raku.
