### PR TITLE
Separate `fish` into its own language

### DIFF
--- a/gengo/languages.yaml
+++ b/gengo/languages.yaml
@@ -61,14 +61,6 @@
       - ".env"
     patterns:
       - ".env.*" # .env.local, .env.example
-fish:  # NOTE: fish is always lowercase in their documentation
-  category: programming
-  color: "#4AAE47"
-  matchers:
-    extensions:
-      - fish
-    interpreters:
-      - fish
 ABAP:
   category: programming
   color: "#3C3C3C"
@@ -914,3 +906,11 @@ Zig:
   matchers:
     extensions:
       - zig
+fish:  # NOTE: fish is always lowercase in their documentation
+  category: programming
+  color: "#4AAE47"
+  matchers:
+    extensions:
+      - fish
+    interpreters:
+      - fish

--- a/gengo/languages.yaml
+++ b/gengo/languages.yaml
@@ -61,6 +61,14 @@
       - ".env"
     patterns:
       - ".env.*" # .env.local, .env.example
+fish:  # NOTE: fish is always lowercase in their documentation
+  category: programming
+  color: "#4AAE47"
+  matchers:
+    extensions:
+      - fish
+    interpreters:
+      - fish
 ABAP:
   category: programming
   color: "#3C3C3C"
@@ -807,12 +815,10 @@ Shell:
   matchers:
     extensions:
       - bash
-      - fish
       - sh
       - zsh
     interpreters:
       - bash
-      - fish
       - sh
       - zsh
 Solidity:

--- a/samples-test/samples/fish/mkcd.fish
+++ b/samples-test/samples/fish/mkcd.fish
@@ -1,0 +1,4 @@
+function mkcd --wraps=mkdir --description 'Make a directory and cd into it' --argument directory
+mkdir -p $directory
+cd $directory
+end


### PR DESCRIPTION
fish diverges enough from other shells that it should be its own language. In fact, it intentionally is not POSIX compliant.