### PR TITLE
Drop `once_cell` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,7 +520,6 @@ dependencies = [
  "ignore",
  "indexmap",
  "insta",
- "once_cell",
  "owo-colors",
  "proc-macro2",
  "quote",

--- a/gengo/Cargo.toml
+++ b/gengo/Cargo.toml
@@ -26,7 +26,6 @@ gix = { version = ">= 0.56, <= 0.64", default-features = false, features = [
 glob = "0.3"
 ignore = "0.4"
 indexmap = { workspace = true, features = ["rayon", "serde"] }
-once_cell = "1"
 owo-colors = { workspace = true, optional = true }
 rayon = "1"
 regex = "1"
@@ -42,7 +41,6 @@ quote = "1"
 [dev-dependencies]
 criterion = { version = "0.5", default-features = false, features = ["rayon", "cargo_bench_support"] }
 insta = "1"
-once_cell = "1"
 rstest = { version = "0.21", default-features = false }
 serde_yaml = "0.9"
 

--- a/gengo/src/language/mod.rs
+++ b/gengo/src/language/mod.rs
@@ -1,9 +1,9 @@
 use crate::GLOB_MATCH_OPTIONS;
-use once_cell::sync::Lazy;
 use regex::Regex;
 use std::collections::HashMap;
 use std::path::Path;
 use std::str::FromStr;
+use std::sync::LazyLock;
 
 macro_rules! _include {
     ($path:literal) => {
@@ -59,7 +59,7 @@ impl Language {
         // NOTE Handle trailing spaces, `\r`, etc.
         let first_line = first_line.trim_end();
 
-        static RE: Lazy<Regex> = Lazy::new(|| {
+        static RE: LazyLock<Regex> = LazyLock::new(|| {
             Regex::new(r"^#!(?:/usr(?:/local)?)?/bin/(?:env\s+)?([\w\d]+)\r?$").unwrap()
         });
 
@@ -79,7 +79,7 @@ impl Language {
             patterns: Vec<glob::Pattern>,
             language: Language,
         }
-        static GLOB_MAPPINGS: Lazy<Vec<GlobMapping>> = Lazy::new(|| {
+        static GLOB_MAPPINGS: LazyLock<Vec<GlobMapping>> = LazyLock::new(|| {
             Language::glob_mappings()
                 .into_iter()
                 .map(|(patterns, language)| {
@@ -105,7 +105,7 @@ impl Language {
 
     /// Filters an iterable of languages by heuristics.
     fn filter_by_heuristics(languages: &[Self], contents: &str) -> Vec<Self> {
-        static HEURISTICS: Lazy<HashMap<Language, Vec<Regex>>> = Lazy::new(|| {
+        static HEURISTICS: LazyLock<HashMap<Language, Vec<Regex>>> = LazyLock::new(|| {
             Language::heuristic_mappings()
                 .into_iter()
                 .map(|(language, patterns)| {

--- a/gengo/tests/language_tests.rs
+++ b/gengo/tests/language_tests.rs
@@ -1,6 +1,6 @@
 use gengo::Language;
-use std::sync::LazyLock;
 use std::collections::HashMap;
+use std::sync::LazyLock;
 
 const LANGUAGES: &str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/languages.yaml"));
 static LANGUAGES_MAP: LazyLock<HashMap<String, serde_yaml::Value>> =

--- a/gengo/tests/language_tests.rs
+++ b/gengo/tests/language_tests.rs
@@ -1,10 +1,10 @@
 use gengo::Language;
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 use std::collections::HashMap;
 
 const LANGUAGES: &str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/languages.yaml"));
-static LANGUAGES_MAP: Lazy<HashMap<String, serde_yaml::Value>> =
-    Lazy::new(|| serde_yaml::from_str(LANGUAGES).unwrap());
+static LANGUAGES_MAP: LazyLock<HashMap<String, serde_yaml::Value>> =
+    LazyLock::new(|| serde_yaml::from_str(LANGUAGES).unwrap());
 
 fn get_matchers(name: &str) -> Vec<(String, Vec<String>)> {
     LANGUAGES_MAP


### PR DESCRIPTION
This drops the `once_cell` dependency, used for the `Lazy` type, in favor of the `LazyLock` introduced to the standard library in Rust 1.80.
