### PR TITLE
Fix Rust version too low in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1-alpine3.18
+FROM rust:1-alpine3.19
 WORKDIR app
 COPY . .
 RUN apk --update add cmake make musl-dev pkgconfig && \


### PR DESCRIPTION
After setting the MSRV, the Rust version installed in the base image was
no longer high enough. Bumping the base image's version should fix that.
