### PR TITLE
Add reStructed Text (ReST) support

### DIFF
--- a/gengo/languages.yaml
+++ b/gengo/languages.yaml
@@ -790,8 +790,8 @@ reStructured Text:
   color: "#141414"
   matchers:
     extensions:
-      - rst
       - rest
+      - rst
 Ruby:
   category: programming
   color: "#D21304"

--- a/gengo/languages.yaml
+++ b/gengo/languages.yaml
@@ -785,6 +785,13 @@ Regex:
   matchers:
     extensions:
       - rpy
+reStructured Text:
+  category: prose
+  color: "#141414"
+  matchers:
+    extensions:
+      - rst
+      - rest
 Ruby:
   category: programming
   color: "#D21304"

--- a/gengo/languages.yaml
+++ b/gengo/languages.yaml
@@ -785,13 +785,6 @@ Regex:
   matchers:
     extensions:
       - rpy
-reStructured Text:
-  category: prose
-  color: "#141414"
-  matchers:
-    extensions:
-      - rest
-      - rst
 Ruby:
   category: programming
   color: "#D21304"
@@ -1040,3 +1033,10 @@ fish:  # NOTE: fish is always lowercase in their documentation
       - fish
     interpreters:
       - fish
+reStructured Text:
+  category: prose
+  color: "#141414"
+  matchers:
+    extensions:
+      - rest
+      - rst

--- a/samples-test/samples/reStructured Text/example.rst
+++ b/samples-test/samples/reStructured Text/example.rst
@@ -1,0 +1,119 @@
+===============================
+reStructuredText Syntax Guide
+===============================
+
+Basic Formatting
+---------------
+*italic text*
+**bold text**
+``inline code``
+
+Headers
+-------
+Level 1
+=======
+
+Level 2
+-------
+
+Level 3
+~~~~~~~
+
+Lists
+-----
+* Bullet point
+* Another point
+    * Subpoint
+    * Another subpoint
+
+1. Numbered list
+2. Second item
+#. Auto-numbered item
+
+Links
+-----
+`Link text <https://example.com>`_
+External link_
+.. _link: https://example.com
+
+Code Blocks
+----------
+.. code-block:: python
+
+        def hello():
+                print("Hello World")
+
+Tables
+------
++------------+------------+
+| Header 1   | Header 2   |
++============+============+
+| Cell 1     | Cell 2     |
++------------+------------+
+
+Simple Table:
+===========  ===========
+Header 1     Header 2
+===========  ===========
+Row 1        Value
+Row 2        Value
+===========  ===========
+
+Images
+------
+.. image:: path/to/image.jpg
+     :width: 100
+     :alt: Alt text
+
+Notes & Warnings
+---------------
+.. note::
+     This is a note
+
+.. warning::
+     This is a warning
+
+Directives
+----------
+.. contents:: Table of Contents
+     :depth: 2
+
+.. sidebar:: Sidebar Title
+     :subtitle: Optional subtitle
+
+     Sidebar content
+
+.. topic:: Topic Title
+
+     Topic content
+
+Cross-References
+---------------
+.. _my-reference-label:
+
+Section Title
+------------
+Reference to :ref:`my-reference-label`
+
+Footnotes
+---------
+A footnote reference [1]_
+
+.. [1] This is the footnote content
+
+Comments
+--------
+.. This is a comment
+
+Line Blocks
+----------
+| Line blocks preserve
+| line breaks and
+| leading whitespace
+
+Definition Lists
+---------------
+term
+        Definition of the term
+another term
+        Definition of another term


### PR DESCRIPTION
This pull request adds the language reStructed Text and sample for it.

- [x] *(not applicable)* If this language conflicts with another language (same extension), I've added heuristics
- [x] *(not applicable)* If this language conflicts with another language, I've linked to the pull request that added the other language here:

Notes: In `linguist` this language [also have](https://github.com/github-linguist/linguist/blob/1647b5be1658fb15a5e09bf89067f79b392301e2/lib/linguist/languages.yml#L8744) `.rst.txt` and `.rest.txt` extensions, but I don't know how to add them.