### PR TITLE
Fetch `test/javascript` when creating Devcontainer

### DIFF
--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -1,2 +1,11 @@
 #!/bin/sh
 cargo install --locked cargo-insta taplo-cli
+
+# Get remote URL
+origin=$(git config --get remote.origin.url)
+
+if [ "$origin" = "https://github.com/spenserblack/gengo" ]; then
+  git fetch origin test/javascript:test/javascript
+else
+  git fetch upstream test/javascript:test/javascript
+fi


### PR DESCRIPTION
Closes #138 
# Description
I've updated `postCreate.sh` script to firstly check origin and if it's equal to `https://github.com/spenserblack/gengo`, run `git fetch origin test/javascript:test/javascript`, else `git fetch upstream test/javascript:test/javascript`