### PR TITLE
Add support and example for TypeSpec

### DIFF
--- a/gengo/languages.yaml
+++ b/gengo/languages.yaml
@@ -940,6 +940,12 @@ TypeScript:
       - tsx
     interpreters:
       - deno
+TypeSpec:
+  category: data
+  color: "#4A3665"
+  matchers:
+    extensions:
+      - tsp
 VHDL:
   category: programming
   color: "#888888"

--- a/samples-test/samples/TypeSpec/main.tsp
+++ b/samples-test/samples/TypeSpec/main.tsp
@@ -1,0 +1,44 @@
+import "@typespec/http";
+
+using Http;
+@service(#{ title: "Widget Service" })
+namespace DemoService;
+
+model Widget {
+  id: string;
+  weight: int32;
+  color: "red" | "blue";
+}
+
+model WidgetList {
+  items: Widget[];
+}
+
+@error
+model Error {
+  code: int32;
+  message: string;
+}
+
+model AnalyzeResult {
+  id: string;
+  analysis: string;
+}
+
+@route("/widgets")
+@tag("Widgets")
+interface Widgets {
+  /** List widgets */
+  @get list(): WidgetList | Error;
+  /** Read widgets */
+  @get read(@path id: string): Widget | Error;
+  /** Create a widget */
+  @post create(@body body: Widget): Widget | Error;
+  /** Update a widget */
+  @patch update(@path id: string, @body body: MergePatchUpdate<Widget>): Widget | Error;
+  /** Delete a widget */
+  @delete delete(@path id: string): void | Error;
+
+  /** Analyze a widget */
+  @route("{id}/analyze") @post analyze(@path id: string): AnalyzeResult | Error;
+}


### PR DESCRIPTION
This pull request adds support for the [TypeSpec](https://typespec.io) language, designed by Microsoft.

Adding this language does not cause any file extension conflicts with other languages.
The sample code was generated using `tsp init`.

- [ ] If this language conflicts with another language (same extension), I've added heuristics
- [ ] If this language conflicts with another language, I've linked to the pull request that added the other language here: