### PR TITLE
Distinguish Coq from Verilog in .v files

### DIFF
--- a/gengo-language/languages.yaml
+++ b/gengo-language/languages.yaml
@@ -223,7 +223,7 @@ Coq:
   category: programming
   color: "#D0B68C"
   heuristics:
-    - '(?m)^\s*(Require\s+(Import|Export)|Theorem|Lemma|Definition|Inductive|Fixpoint|Proof|Qed|Notation)\b'
+    - '(?m)^\s*(Require\s+(Import|Export)\s|(Theorem|Lemma|Definition|Inductive|Fixpoint|Notation)\s|(Proof|Qed)\s*\.)'
   matchers:
     extensions:
       - v
@@ -1010,7 +1010,7 @@ Verilog:
   category: programming
   color: "#088020"
   heuristics:
-    - '(?m)^\s*(module|endmodule|always|assign|initial)\b'
+    - '(?m)^\s*(module|endmodule|always|assign|initial)\s'
   matchers:
     extensions:
       - v

--- a/gengo-language/languages.yaml
+++ b/gengo-language/languages.yaml
@@ -222,6 +222,8 @@ Common Lisp:
 Coq:
   category: programming
   color: "#D0B68C"
+  heuristics:
+    - '(?m)^\s*(Require\s+(Import|Export)|Theorem|Lemma|Definition|Inductive|Fixpoint|Proof|Qed|Notation)\b'
   matchers:
     extensions:
       - v
@@ -1007,6 +1009,8 @@ Vala:
 Verilog:
   category: programming
   color: "#088020"
+  heuristics:
+    - '(?m)^\s*(module|endmodule|always|assign|initial)\b'
   matchers:
     extensions:
       - v

--- a/samples-test/samples/Coq/nat_tree.v
+++ b/samples-test/samples/Coq/nat_tree.v
@@ -1,0 +1,17 @@
+Require Import Coq.Arith.Arith.
+
+(* A small binary tree over natural numbers. *)
+Inductive tree : Type :=
+  | Leaf
+  | Node (l : tree) (value : nat) (r : tree).
+
+Fixpoint size (t : tree) : nat :=
+  match t with
+  | Leaf => 0
+  | Node l _ r => 1 + size l + size r
+  end.
+
+Theorem size_leaf : size Leaf = 0.
+Proof.
+  simpl. reflexivity.
+Qed.

--- a/samples-test/samples/Verilog/counter.v
+++ b/samples-test/samples/Verilog/counter.v
@@ -1,0 +1,17 @@
+`timescale 1ns / 1ps
+
+// A simple parameterized up-counter with asynchronous reset.
+module counter #(
+    parameter WIDTH = 8
+) (
+    input  wire             clk,
+    input  wire             rst_n,
+    output reg  [WIDTH-1:0] count
+);
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) count <= {WIDTH{1'b0}};
+    else count <= count + 1'b1;
+  end
+
+endmodule


### PR DESCRIPTION
## Summary

Coq and Verilog both claim the `.v` extension, but neither had `heuristics`, so any `.v` file was always classified as Verilog (a Coq file was misclassified).

This adds content heuristics to disambiguate them, using the `regex`-crate syntax and following the existing pattern (like C / C# / C++):

- **Coq**: `Require Import/Export`, `Theorem`, `Lemma`, `Definition`, `Inductive`, `Fixpoint`, `Proof`, `Qed`, `Notation`.
- **Verilog**: `module`, `endmodule`, `always`, `assign`, `initial`.

The regexes are case-sensitive, so Coq's capitalized `Module` is not confused with Verilog's lowercase `module`.

## Samples

Added `samples-test/samples/Coq/nat_tree.v` and `samples-test/samples/Verilog/counter.v`. I wrote both samples myself, and agree they are licensed under this repository's licenses.

## Testing

- Before the change, `samples-test` failed: the Coq sample was detected as Verilog.
- After adding the heuristics, `cargo test -p samples-test` passes (every sample classifies correctly) and `cargo test -p gengo-language` passes.
- Manually verified `languages.yaml` still satisfies `scripts/check-languages-file.rb` (language ordering, required keys, `heuristics` as an array, and matcher ordering are all unchanged).

Closes #411.
